### PR TITLE
Fix problem I ran into regarding current_user

### DIFF
--- a/app/controllers/forem/application_controller.rb
+++ b/app/controllers/forem/application_controller.rb
@@ -13,8 +13,4 @@ class Forem::ApplicationController < ApplicationController
       redirect_to forums_path #TODO: not positive where to redirect here
     end
   end
-
-  # dummy method
-  def current_user
-  end
 end

--- a/app/controllers/forem/forums_controller.rb
+++ b/app/controllers/forem/forums_controller.rb
@@ -8,6 +8,8 @@ module Forem
 
     def show
       @forum = Forem::Forum.find(params[:id])
+      # TODO: Pagination
+      @topics = @forum.topics
     end
 
     def new

--- a/app/controllers/forem/forums_controller.rb
+++ b/app/controllers/forem/forums_controller.rb
@@ -1,7 +1,7 @@
 module Forem
   class ForumsController < Forem::ApplicationController
     before_filter :authenticate_forem_admin, :only => [:new, :create]
-    
+
     def index
       @forums = Forem::Forum.all
     end
@@ -9,11 +9,11 @@ module Forem
     def show
       @forum = Forem::Forum.find(params[:id])
     end
-    
+
     def new
       @forum = Forem::Forum.new
     end
-    
+
     def create
       @forum = Forem::Forum.new(params[:forum])
       if @forum.save

--- a/app/views/forem/forums/show.html.erb
+++ b/app/views/forem/forums/show.html.erb
@@ -4,4 +4,6 @@
     <%= render :partial => "forem/forums/forum", :locals => { :forum => @forum } %>
   </div>
 </div>
+
 <%= link_to "Post a new topic.", new_forum_topic_path(@forum) -%>
+<%= render :partial => 'forem/topics/topic_listing', :collection => @topics %>

--- a/app/views/forem/forums/show.html.erb
+++ b/app/views/forem/forums/show.html.erb
@@ -4,3 +4,4 @@
     <%= render :partial => "forem/forums/forum", :locals => { :forum => @forum } %>
   </div>
 </div>
+<%= link_to "Post a new topic.", new_forum_topic_path(@forum) -%>

--- a/app/views/forem/topics/_topic_listing.html.erb
+++ b/app/views/forem/topics/_topic_listing.html.erb
@@ -1,0 +1,6 @@
+<div id='topic'>
+  <h2><%= topic_listing.subject %></h2>
+  <menu>
+    <%= link_to "View", forum_topic_path(@forum, topic_listing) %>
+  </menu>
+</div>

--- a/spec/integration/forums_spec.rb
+++ b/spec/integration/forums_spec.rb
@@ -16,18 +16,18 @@ describe "forums" do
       page.should have_content("Welcome to Forem!")
     end
   end
-  
+
   context "not signed in admins" do
     before do
       sign_in!
     end
-    
+
     it "cannot create a new forum" do
       visit new_forum_path
       flash_error!("Access denied.")
     end
   end
-  
+
   context "signed in admins" do
     before do
       sign_in! :admin => true
@@ -52,7 +52,7 @@ describe "forums" do
         flash_error!("This forum could not be created.")
         find_field("forum_title").value.should eql("")
       end
-      
+
       it "is invalid without description" do
         fill_in "Title", :with => "FIRST FORUM."
         click_button 'Create Forum'


### PR DESCRIPTION
[controller] remove current_user from application controller, because it overrides it in other controllers it would seem.

When I made an example project with actual logins, it was failing to see when I was logged in because current_user is overridden in Forem::ApplicationController.  Removed this, login worked as expected and specs all still pass.
