### PR TITLE
Attach posts to users

### DIFF
--- a/app/controllers/forem/posts_controller.rb
+++ b/app/controllers/forem/posts_controller.rb
@@ -9,6 +9,7 @@ module Forem
   
     def create
       @post = @topic.posts.build(params[:post])
+      @post.user = current_user
       if @post.save
         flash[:notice] = t("forem.post.created")
         redirect_to [@topic.forum, @topic]

--- a/spec/integration/posts_spec.rb
+++ b/spec/integration/posts_spec.rb
@@ -30,6 +30,10 @@ describe "posts" do
       end
 
       it "can post a reply to a topic" do
+        # FIXME: This is only necessary because of how current_user is mocked in sign_in!.
+        # Once that's fixed this can go away and the spec should pass.
+        User.delete_all
+
         fill_in "Text", :with => "Witty and insightful commentary."
         click_button "Post Reply"
         flash_notice!("Your reply has been posted.")


### PR DESCRIPTION
This will attach posts to current_user when created.  I also had to do something moderately unpleasant in a spec because of how current_user is mocked in sign_in! at present....if it's too ugly of a hack, I'm open to ideas on how we fix the sign_in! mockout.
