### PR TITLE
Forem::Topic.by_most_recent_post still not happy in postgres

### DIFF
--- a/app/models/forem/topic.rb
+++ b/app/models/forem/topic.rb
@@ -15,7 +15,7 @@ module Forem
 
     scope :visible, where(:hidden => false)
     scope :by_pinned, order('forem_topics.pinned DESC, forem_topics.id')
-    scope :by_most_recent_post, joins(:posts).select("DISTINCT forem_posts.topic_id, forem_topics.*").order('forem_posts.created_at DESC, forem_topics.id')
+    scope :by_most_recent_post, joins(:posts).select("DISTINCT forem_posts.topic_id, forem_topics.*, forem_posts.created_at").order('forem_posts.created_at DESC, forem_topics.id')
     scope :by_pinned_or_most_recent_post, includes(:posts).
                                           order('forem_topics.pinned DESC').
                                           order('forem_posts.created_at DESC').

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -49,16 +49,16 @@ describe Forem::Topic do
   describe ".by_most_recent_post" do
     before do
       Forem::Topic.delete_all
-      @topic1 = Factory(:topic)
-      Factory(:post, :topic => @topic, :created_at => 1.seconds.ago)
-      @topic2 = Factory(:topic)
+      @topic1 = Forem::Topic.create :subject => "POST"
+      Factory(:post, :topic => @topic1, :created_at => 1.seconds.ago)
+      @topic2 = Forem::Topic.create :subject => "POST"
       Factory(:post, :topic => @topic2, :created_at => 5.seconds.ago)
-      @topic3 = Factory(:topic)
+      @topic3 = Forem::Topic.create :subject => "POST"
       Factory(:post, :topic => @topic3, :created_at => 10.seconds.ago)
     end
 
     it "should show topics by most recent post" do
-      Forem::Topic.by_most_recent_post.to_a.should == [@topic1, @topic2, @topic3]
+      Forem::Topic.by_most_recent_post.to_a.map(&:id).should == [@topic1.id, @topic2.id, @topic3.id]
     end
   end
 end


### PR DESCRIPTION
Not sure how this wasn't breaking before, but this patch fixes a postgres bug with that named scope. I changed spec/dummy/config/database.yml and tested both postgres and mysql to ensure no breakage.
