### PR TITLE
Added default value of false to locked topics migration

### DIFF
--- a/db/migrate/20110519210300_add_locked_to_topics.rb
+++ b/db/migrate/20110519210300_add_locked_to_topics.rb
@@ -1,5 +1,5 @@
 class AddLockedToTopics < ActiveRecord::Migration
   def change
-    add_column :forem_topics, :locked, :boolean
+    add_column :forem_topics, :locked, :boolean, :null => false, :default => false
   end
 end


### PR DESCRIPTION
Added default value of false to locked topics migration. This prevents needing to use !!topic.locked to coerce it from nil into true or false.
