### PR TITLE
removes and ignores .rvmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tmp
 spec/dummy/log
 spec/dummy/db/*.sqlite3
 *.rbc
+.rvmrc

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use 1.9.2@forem


### PR DESCRIPTION
which should be developer preference not project setting, as common in other repos.

I think this was probably added to git by accident?

The only quirk with this commit is it will probably delete your local .rvmrc file, but it's easy to recreate it?
