### PR TITLE
test for "can't delete other people's posts"

### DIFF
--- a/spec/integration/posts_spec.rb
+++ b/spec/integration/posts_spec.rb
@@ -94,6 +94,13 @@ describe "posts" do
           flash_notice!("Your post has been deleted.")
         end
 
+        it "cannot delete posts by others" do
+          other_post = topic.posts[1]
+          #sends delete request with the current rack-test logged-in session & follows the redirect
+          Capybara.current_session.driver.submit :delete, topic_post_path(topic, other_post), {}
+          flash_alert!("You cannot delete a post you do not own.")
+          ::Forem::Post.should exist(other_post.id)
+        end
       end
 
       context "topic contains one post" do


### PR DESCRIPTION
I noticed this was deleted in a previous commit, likely out of frustration @ capybara not doing what was expected with the delete request (it drops the rack-test session, losing the log-in, or something like that).

This version of the test passes.
