### PR TITLE
Polish translations of models attributes and a few other and indicators to them in english translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,9 @@ en:
         topics: Topics
         posts: Posts
         delete_confirm: Are you sure you want to delete this forum?
+        index:
+          last_post: Last post
+          none: None
     common:
       pages: Pages
     errors:
@@ -28,6 +31,7 @@ en:
     forum:
       header: "Viewing %{title}"
       forums: Forums
+      new: Creating a new forum
       topics_count:
         zero: 0 topics
         one: 1 topic
@@ -56,6 +60,7 @@ en:
       delete: Delete
       created: This topic has been created.
       new: Creating a new topic
+      edit: Editing topic
       not_created: This topic could not be created.
       deleted: Your topic has been deleted.
       cannot_delete: You cannot delete a topic you do not own.
@@ -101,6 +106,20 @@ en:
       deleted_with_topic: Only post in topic deleted. Topic also deleted.
       cannot_delete: You cannot delete a post you do not own.
       in_reply_to: In reply to
+  simple_form:
+    labels:
+      forum:
+        title: Title
+        description: Description
+      topic:
+        subject: Title
+        locked: Locked
+        pinned: Pinned
+        hidden: Hidden
+        posts:
+          text: Text
+      post:
+        text: Text
   refinery:
     plugins:
       refinery_forem:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,6 @@ en:
       area: Admin Area
       welcome: "Welcome to forem's Admin Area."
       forum:
-        edit: "Editing the %{title} forum"
         index: Manage Forums
         new: Creating a new forum
         new_link: New Forum
@@ -32,6 +31,7 @@ en:
       header: "Viewing %{title}"
       forums: Forums
       new: Creating a new forum
+      edit: "Editing the %{title} forum"
       topics_count:
         zero: 0 topics
         one: 1 topic
@@ -106,6 +106,14 @@ en:
       deleted_with_topic: Only post in topic deleted. Topic also deleted.
       cannot_delete: You cannot delete a post you do not own.
       in_reply_to: In reply to
+  helpers:
+    submit:
+      forum:
+        create: Create Forum
+        update: Update Forum
+      topic:
+        create: Create Topic
+        update: Update Topic
   simple_form:
     labels:
       forum:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -4,7 +4,6 @@ pl:
       area: Panel administracyjny
       welcome: Witaj w panelu administracyjnym Forem.
       forum:
-        edit: "Edytuj forum %{title}"
         index: Zarządzanie forami
         new: Dodaj forum
         new_link: Dodaj forum
@@ -32,6 +31,7 @@ pl:
       header: "Przeglądasz %{title}"
       forums: Fora
       new: Dodawanie nowego forum
+      edit: "Edytujesz forum %{title}"
       topics_count:
         zero: 0 tematów
         one: 1 temat
@@ -108,6 +108,14 @@ pl:
       deleted_with_topic: Tylko post w temacie usunięty. Temat również usunięty.
       cannot_delete: Nie możesz usunąć wpisu, którego nie dodałeś.
       in_reply_to: Odpowiedź na wypowiedź użytkownika
+  helpers:
+    submit:
+      forum:
+        create: Utwórz forum
+        update: Aktualizuj forum
+      topic:
+        create: Utwórz temat
+        update: Aktualizuj temat
   simple_form:
     topic: Temat
     labels:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -107,7 +107,7 @@ pl:
       deleted: Twój wpis został usunięty.
       deleted_with_topic: Tylko post w temacie usunięty. Temat również usunięty.
       cannot_delete: Nie możesz usunąć wpisu, którego nie dodałeś.
-      in_reply_to: Odpowiedź na wypowiedź użytkownika
+      in_reply_to: W odpowiedzi na wypowiedź użytkownika
   helpers:
     submit:
       forum:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -61,7 +61,7 @@ pl:
       quote: Cytuj
       delete: Usuń
       created: Temat został dodany.
-      new: Dodawanie nowego tematu
+      new: Tworzenie nowego tematu
       edit: Edycja tematu
       not_created: Temat nie został dodany.
       deleted: Temat został usunięty.

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -20,6 +20,9 @@ pl:
         topics: Tematy
         posts: Posty
         delete_confirm: Czy na pewno chcesz usunąć to forum?
+        index:
+          last_post: Ostatni post
+          none: Brak
     common:
       pages: Strony
     errors:
@@ -28,6 +31,7 @@ pl:
     forum:
       header: "Przeglądasz %{title}"
       forums: Fora
+      new: Dodawanie nowego forum
       topics_count:
         zero: 0 tematów
         one: 1 temat
@@ -57,7 +61,8 @@ pl:
       quote: Cytuj
       delete: Usuń
       created: Temat został dodany.
-      new: Dodaj temat
+      new: Dodawanie nowego tematu
+      edit: Edycja tematu
       not_created: Temat nie został dodany.
       deleted: Temat został usunięty.
       cannot_delete: Nie możesz usunąć tematu, którego nie dodałeś.
@@ -102,7 +107,22 @@ pl:
       deleted: Twój wpis został usunięty.
       deleted_with_topic: Tylko post w temacie usunięty. Temat również usunięty.
       cannot_delete: Nie możesz usunąć wpisu, którego nie dodałeś.
-      in_reply_to: Odpowiedź użytkownikowi
+      in_reply_to: Odpowiedź na wypowiedź użytkownika
+  simple_form:
+    topic: Temat
+    labels:
+      forum:
+        title: Tytuł
+        description: Opis
+      topic:
+        subject: Temat
+        locked: Zablokowany
+        pinned: Przypięty
+        hidden: Ukryty
+        posts:
+          text: Tekst
+      post:
+        text: Tekst
   refinery:
     plugins:
       refinery_forem:


### PR DESCRIPTION
I've added polish translations of models attributes and indicators to them in english translation, so that when somebody will update some other language translation, he will new what to translate :)

I've mentioned that problem previously in that issue: https://github.com/radar/forem/issues/60

I've find out in simple_form readme that it looks for attributes like this: `simple_form.labels.model.attribute`

But there is still problem with models names translations, but I will describe it on that previous issue
