### PR TITLE
remove 'text' label on the new post form, its not really needed

### DIFF
--- a/app/views/forem/posts/_form.html.erb
+++ b/app/views/forem/posts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= f.input :text %>
+<%= f.input :text, :label => false %>
 <% if params[:reply_to_id] %>
   <%= f.hidden_field :reply_to_id, :value => params[:reply_to_id] %>
 <% end %>


### PR DESCRIPTION
Hey guys, right now on the create post form there is a label that just says 'Text', it looks kind of out of place and I don't think we need it so this just removes it
