### PR TITLE
current_user usage in application_controller should be forem_user?

### DIFF
--- a/app/controllers/forem/application_controller.rb
+++ b/app/controllers/forem/application_controller.rb
@@ -7,7 +7,7 @@ class Forem::ApplicationController < ApplicationController
   end
 
   def current_ability
-    Forem::Ability.new(current_user)
+    Forem::Ability.new(forem_user)
   end
 
   private

--- a/app/models/forem/forum.rb
+++ b/app/models/forem/forum.rb
@@ -9,8 +9,8 @@ module Forem
     validates :title, :presence => true
     validates :description, :presence => true
 
-    def last_post_for(current_user)
-      current_user && current_user.forem_admin? ? posts.last : last_visible_post
+    def last_post_for(forem_user)
+      forem_user && forem_user.forem_admin? ? posts.last : last_visible_post
     end
 
     def last_visible_post

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <div id='flash_<%= key %>'><%= message %></div>
   <% end %>
   <% if user_signed_in? %>
-    Signed in as <%= current_user %>
+    Signed in as <%= forem_user %>
     <%= link_to "Sign out", main_app.destroy_user_session_path, :method => :delete %>
   <% end %>
 


### PR DESCRIPTION
Forem is using 'current_user' in its application_controller. It should be changed here to 'forem_user', otherwise one needs to separately define a current_user method in the app's application_controller.

I fixed this in application_controller and also changes the name elsewhere.

I've not run tests yet on this change, though.
