### PR TITLE
Installer creates a forum and topic

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,10 @@
+user = Forem.user_class.first
+unless user.nil?
+  forum = Forem::Forum.find_or_create_by_title( :category_id => Forem::Category.first.id, 
+                               :title => "Default",
+                               :description => "Default forem created by install")
+  topic = Forem::Topic.find_or_create_by_subject( :forum_id => forum.id,
+                               :user_id => user.id, 
+                               :subject => "Welcome to forem!", 
+                               :posts_attributes => [{:text => "Hello World", :user_id => user.id}])
+end

--- a/lib/generators/forem/install_generator.rb
+++ b/lib/generators/forem/install_generator.rb
@@ -78,6 +78,12 @@ module Forem
         end
       end
 
+      def seed_database
+        unless options["no-migrate"]
+          puts "Creating default forum and topic"
+          Forem::Engine.load_seed
+        end
+      end
 
       def mount_engine
         puts "Mounting Forem::Engine at \"/forums\" in config/routes.rb..."
@@ -101,7 +107,8 @@ Here's what happened:\n\n}
    This is where you put Forem's configuration settings.\n")
         
         unless options["no-migrate"]
-output += step("`rake db:migrate` was run, running all the migrations against your database.")
+output += step("`rake db:migrate` was run, running all the migrations against your database.\n")
+        output += step("Seed forum and topic were loaded into your database.\n")
         end
         output += step("The engine was mounted in your config/routes.rb file using this line:
 

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -69,4 +69,16 @@ describe Forem::Generators::InstallGenerator do
     application_controller.should include(expected_forem_user_method)
   end
 
+  it "seeds the database" do
+    Forem::Forum.count.should == 0
+    Forem::Topic.count.should == 0
+
+    FactoryGirl.create(:user)
+    FactoryGirl.create(:category)
+    Forem::Engine.load_seed
+
+    Forem::Forum.count.should == 1
+    Forem::Topic.count.should == 1
+  end
+
 end


### PR DESCRIPTION
Hey guys,
I took a stab at handling issue #91, making the installer create a default forum & topic.
Let me know if you have any suggestions.

The one thing thats kinda weird about this is that I am just using the first user in the db as the user that creates the topic & forum, I think its better than creating a new user in the db specifically for this, but I'm open to other approaches.

thanks
