### PR TITLE
Fix bug with seeds on fresh install

### DIFF
--- a/lib/generators/forem/install_generator.rb
+++ b/lib/generators/forem/install_generator.rb
@@ -79,6 +79,7 @@ module Forem
       end
 
       def seed_database
+        load "#{Rails.root}/config/initializers/forem.rb"
         unless options["no-migrate"]
           puts "Creating default forum and topic"
           Forem::Engine.load_seed


### PR DESCRIPTION
We need to force forem.rb to be loaded after it is copied over so that we can reference user_class in our seeds.
