### PR TITLE
Fixes autoload problem 

### DIFF
--- a/app/helpers/forem/admin/groups_helper.rb
+++ b/app/helpers/forem/admin/groups_helper.rb
@@ -1,4 +1,6 @@
 module Forem
-  module Admin::GroupsHelper
+  module Admin
+    module GroupsHelper
+    end
   end
 end


### PR DESCRIPTION
So I've been getting this error:

```
/home/gleb/.rvm/gems/ruby-1.9.2-p290@mr/gems/activesupport-3.2.1/lib/active_support/dependencies.rb:503:in `load_missing_constant': Expected /home/gleb/.rvm/gems/ruby-1.9.2-p290@mr/bundler/gems/forem-620a071a159e/app/helpers/forem/admin/groups_helper.rb to define Forem::Admin::GroupsHelper (LoadError)
    from /home/gleb/.rvm/gems/ruby-1.9.2-p290@mr/gems/activesupport-3.2.1
```

The pull request fixes it
