### PR TITLE
Fixes some nil references

### DIFF
--- a/app/models/forem/topic.rb
+++ b/app/models/forem/topic.rb
@@ -149,7 +149,9 @@ module Forem
       if state_changed?
         first_post = self.posts.by_created_at.first
         first_post.approve! unless first_post.approved?
-        self.user.update_attribute(:forem_state, 'approved') if self.user.forem_state != 'approved'
+        if self.user
+          self.user.update_attribute(:forem_state, 'approved') if self.user.forem_state != 'approved'
+        end
       end
     end
   end

--- a/app/views/forem/topics/show.html.erb
+++ b/app/views/forem/topics/show.html.erb
@@ -5,7 +5,7 @@
     <% if @topic.can_be_replied_to? && can?(:reply, @topic) %>
       <%= link_to t(".reply"), new_topic_post_path(@topic) %>
     <% end %>
-    <% if @topic.user == forem_user || forem_admin? %>
+    <% if (@topic.user and @topic.user == forem_user) || forem_admin? %>
       <%= link_to t(".delete"), forum_topic_path(@forum, @topic), :method => :delete, :confirm => t("are_you_sure") %>
     <% end %>
     <% if forem_user %>


### PR DESCRIPTION
In my forum I allowed people to post without signing up for a user account, so those posts were created with User objects that did not have an id set (they were new_record?)

I found a couple of places where adding nil checks avoids crashes.
