### PR TITLE
Fix setting topic.last_post_at value when creating a new post.

### DIFF
--- a/app/models/forem/post.rb
+++ b/app/models/forem/post.rb
@@ -108,7 +108,7 @@ module Forem
     end
 
     def set_topic_last_post_at
-      self.topic.last_post_at = self.created_at
+      self.topic.update_attribute(:last_post_at, self.created_at)
     end
 
     def skip_pending_review_if_user_approved

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -50,6 +50,17 @@ describe Forem::Post do
 
       @post.save!
     end
+
+    it "sets topics last_post_at value" do
+      topic = FactoryGirl.create(:topic)
+      post1 = FactoryGirl.create(:post, :topic => topic)
+      topic.reload
+      topic.last_post_at.should == post1.created_at
+
+      post2 = FactoryGirl.create(:post, :topic => topic)
+      topic.reload
+      topic.last_post_at.should == post2.created_at
+    end
   end
 
   context "helper methods" do


### PR DESCRIPTION
topic.last_post_at was set but topic was not saved. I changed it to use update_attribute.
