### PR TITLE
User model avatars

### DIFF
--- a/app/helpers/forem/posts_helper.rb
+++ b/app/helpers/forem/posts_helper.rb
@@ -1,8 +1,15 @@
 module Forem
   module PostsHelper
     def avatar(user, options = {})
-      if (email = user.try(:email)).present?
-        image_tag(avatar_url(email, options), :alt => "Gravatar")
+      if Forem.avatar_user_method.nil?
+        if (email = user.try(:email)).present?
+          image_tag(avatar_url(email, options), :alt => "Gravatar")
+        end
+      else
+        # Try to use the user's custom avatar method
+        if (avatar = user.try(Forem.avatar_user_method.to_sym)).present?
+          image_tag(avatar, :alt => "Avatar")
+        end
       end
     end
 

--- a/lib/forem.rb
+++ b/lib/forem.rb
@@ -8,7 +8,8 @@ require 'workflow'
 
 module Forem
   mattr_accessor :user_class, :theme, :formatter, :default_gravatar, :default_gravatar_image,
-                 :user_profile_links, :email_from_address, :autocomplete_field
+                 :user_profile_links, :email_from_address, :autocomplete_field,
+                 :avatar_user_method
 
 
   def self.user_class

--- a/lib/generators/forem/install/templates/initializer.rb
+++ b/lib/generators/forem/install/templates/initializer.rb
@@ -1,5 +1,6 @@
 Forem.user_class = "<%= user_class %>"
 Forem.email_from_address = "please-change-me@example.com"
+#Forem.avatar_user_method = "custom_avatar_url" # Method called on user to return an image url for a non-gravatar custom avatar
 
 # If you want to change the layout that Forem uses, uncomment and customize these lines:
 #

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -21,6 +21,17 @@ describe Forem do
     end
   end
 
+
+  describe ".avatar_user_method" do
+    it "can be set and retrieved" do
+      Forem.avatar_user_method = "foo"
+      Forem.avatar_user_method.should eq("foo")
+      
+      Forem.avatar_user_method = nil
+      Forem.avatar_user_method.should be_nil
+    end
+  end
+   
   describe ".email_from_address" do
     it "can be set and retrieved" do
       Forem.email_from_address = "foo"

--- a/spec/lib/generators/forem/dummy/templates/db/migrate/1_create_users.rb
+++ b/spec/lib/generators/forem/dummy/templates/db/migrate/1_create_users.rb
@@ -5,6 +5,7 @@ class CreateUsers < ActiveRecord::Migration
     t.string  :login
     t.boolean :forem_admin,                       :default => false
     t.string :forem_state, :default => "pending_review"
+    t.string :users, :custom_avatar_url
   end
 
   add_index :users, :email, :unique => true

--- a/spec/requests/topics_spec.rb
+++ b/spec/requests/topics_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "topics" do
 
   let(:forum) { FactoryGirl.create(:forum) }
-  let(:user) { FactoryGirl.create(:user, :login => 'other_forem_user', :email => "bob@boblaw.com") }
+  let(:user) { FactoryGirl.create(:user, :login => 'other_forem_user', :email => "bob@boblaw.com", :custom_avatar_url => 'avatar.png') }
   let(:topic) { FactoryGirl.create(:approved_topic, :forum => forum, :user => user) }
   let(:other_user) { FactoryGirl.create(:user, :login => 'other_forem_user') }
   let(:other_topic) { FactoryGirl.create(:approved_topic, :subject => 'Another forem topic', :user => other_user, :forum => forum) }
@@ -147,7 +147,22 @@ describe "topics" do
       visit forum_topic_path(forum, topic)
       assert page.has_selector?("div.icon > img[alt='Gravatar']")
     end
-
+    
+    it "should show a custom avatar when set" do
+      Forem.stub(:avatar_user_method => "custom_avatar_url")
+      
+      visit forum_topic_path(forum, topic)
+      assert page.has_selector?("div.icon > img[alt='Avatar']")
+    end
+    
+    it "should show no avatar with custom method empty" do
+      Forem.stub(:avatar_user_method => "custom_avatar_url")
+      
+      visit forum_topic_path(forum, other_topic)
+      assert page.has_no_selector?("div.icon > img[alt='Gravatar']")
+      assert page.has_no_selector?("div.icon > img[alt='Avatar']")
+    end
+    
     it "should have an autodiscover link tag" do
       visit forum_topic_path(forum, topic)
       assert page.has_selector?("link[title='ATOM']")


### PR DESCRIPTION
Rebased - Includes radar's spec fix - see inline for parndt's comments on the last commit.

I didn't want to use gravatar on a recent project for anonymity but wanted avatars from my current user class. So I've added the ability to set Forem.avatar_user_method to a method to be called on user to return an image url to use as an avatar. If you don't set avatar_user_method you keep the gravatar functionality.
