### PR TITLE
User subscription preferences

### DIFF
--- a/app/models/forem/post.rb
+++ b/app/models/forem/post.rb
@@ -93,7 +93,7 @@ module Forem
     protected
 
     def subscribe_replier
-      if self.topic && self.user
+      if self.topic && self.user && self.user.forem_auto_subscribe
         self.topic.subscribe_user(self.user.id)
       end
     end

--- a/app/models/forem/post.rb
+++ b/app/models/forem/post.rb
@@ -29,7 +29,7 @@ module Forem
     after_save :email_topic_subscribers, :if => Proc.new { |p| p.approved? && !p.notified? }
 
     after_create :set_topic_last_post_at
-    after_create :subscribe_replier, :if => Proc.new { |p| p.user.forem_auto_subscribe? }
+    after_create :subscribe_replier, :if => Proc.new { |p| p && p.user.forem_auto_subscribe? }
     after_create :skip_pending_review_if_user_approved
 
     after_save :approve_user, :if => :approved?

--- a/app/models/forem/post.rb
+++ b/app/models/forem/post.rb
@@ -29,7 +29,7 @@ module Forem
     after_save :email_topic_subscribers, :if => Proc.new { |p| p.approved? && !p.notified? }
 
     after_create :set_topic_last_post_at
-    after_create :subscribe_replier
+    after_create :subscribe_replier, :if => Proc.new { |p| p.user.forem_auto_subscribe }
     after_create :skip_pending_review_if_user_approved
 
     after_save :approve_user, :if => :approved?
@@ -93,7 +93,7 @@ module Forem
     protected
 
     def subscribe_replier
-      if self.topic && self.user && self.user.forem_auto_subscribe
+      if self.topic && self.user
         self.topic.subscribe_user(self.user.id)
       end
     end

--- a/app/models/forem/post.rb
+++ b/app/models/forem/post.rb
@@ -29,7 +29,7 @@ module Forem
     after_save :email_topic_subscribers, :if => Proc.new { |p| p.approved? && !p.notified? }
 
     after_create :set_topic_last_post_at
-    after_create :subscribe_replier, :if => Proc.new { |p| p && p.user.forem_auto_subscribe? }
+    after_create :subscribe_replier, :if => Proc.new { |p| p.user && p.user.forem_auto_subscribe? }
     after_create :skip_pending_review_if_user_approved
 
     after_save :approve_user, :if => :approved?

--- a/app/models/forem/post.rb
+++ b/app/models/forem/post.rb
@@ -29,7 +29,7 @@ module Forem
     after_save :email_topic_subscribers, :if => Proc.new { |p| p.approved? && !p.notified? }
 
     after_create :set_topic_last_post_at
-    after_create :subscribe_replier, :if => Proc.new { |p| p.user.forem_auto_subscribe }
+    after_create :subscribe_replier, :if => Proc.new { |p| p.user.forem_auto_subscribe? }
     after_create :skip_pending_review_if_user_approved
 
     after_save :approve_user, :if => :approved?

--- a/db/migrate/20120414183053_add_forem_auto_subscribe_to_user.rb
+++ b/db/migrate/20120414183053_add_forem_auto_subscribe_to_user.rb
@@ -1,0 +1,5 @@
+class AddForemAutoSubscribeToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :forem_auto_subscribe, :boolean, :default => false
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -16,10 +16,20 @@ describe Forem::Post do
   end
 
   context "after creation" do
-    it "subscribes the current poster" do
+    it "subscribes the current poster if forem_auto_subscribe is set to true" do
       @topic = FactoryGirl.create(:topic)
       @post = FactoryGirl.create(:post, :topic => @topic)
       @topic.subscriptions.last.subscriber.should == @post.user
+    end
+    
+    it "doesn't subscribe the current poster if forem_auto_subscribe is set to false" do
+      @topic = FactoryGirl.create(:topic)
+      @post = FactoryGirl.create(:post, :topic => @topic)
+      
+      @user_not_autosubscribed = FactoryGirl.create(:not_autosubscribed)
+      @post = FactoryGirl.build(:approved_post, :topic => @topic, :user => @user_not_autosubscribed)
+      
+      @topic.subscriptions.last.subscriber.should_not == @post.user_not_autosubscribed
     end
 
     it "does not email subscribers after post creation if not approved" do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -29,7 +29,7 @@ describe Forem::Post do
       @user_not_autosubscribed = FactoryGirl.create(:not_autosubscribed)
       @post = FactoryGirl.build(:approved_post, :topic => @topic, :user => @user_not_autosubscribed)
       
-      @topic.subscriptions.last.subscriber.should_not == @post.user_not_autosubscribed
+      @topic.subscriptions.last.subscriber.should_not == @post.user
     end
 
     it "does not email subscribers after post creation if not approved" do

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -4,9 +4,14 @@ FactoryGirl.define do
     f.email { "bob#{rand(100000)}@boblaw.com" }
     f.password "password"
     f.password_confirmation "password"
+    f.forem_auto_subscribe true
 
     factory :admin do |f|
       f.forem_admin true
+    end
+    
+    factory :not_autosubscribed do |f|
+      f.forem_auto_subscribe false
     end
   end
 end


### PR DESCRIPTION
This branch adds a conditional to the after_save :subscribe_user on post.rb.

The conditional proc checks the forem_auto_subscribe column on the users table. I've also added a migration for this column which defaults to false.

I'm ok with the default being changed to something else but I personally think it's irritating for a user to have to keep mashing the unsubscribe button every time they make a new reply if they don't want to subscribe in the first place. With this, it's easy to allow the user to customize their subscription preferences later.

I've modified the tests and factories slightly to reflect this change. Let me know if everything looks good on your end.

Cheers,
Jeremy
