### PR TITLE
Use h1 tag for highest level forums title heading

### DIFF
--- a/app/views/forem/forums/index.html.erb
+++ b/app/views/forem/forums/index.html.erb
@@ -1,5 +1,5 @@
 <div id='forums_container'>
-  <h2><%= t('.title') %></h2>
+  <h1 id='forums_title'><%= t('.title') %></h1>
 
   <%= render @categories %>
 </div>


### PR DESCRIPTION
This is a very simple tweak that uses h1 for the highest level title ("Forums") for forums index view. This makes it easier to style as a part refinery app (which uses h1 tags for highest level titles by default). Also, it's higher level than category headings, which are h2.
