### PR TITLE
Show the post the user is replying to

### DIFF
--- a/app/controllers/forem/posts_controller.rb
+++ b/app/controllers/forem/posts_controller.rb
@@ -7,9 +7,10 @@ module Forem
     def new
       authorize! :reply, @topic
       @post = @topic.posts.build
+      @reply_to_post = @topic.posts.find_by_id(params[:reply_to_id])
+
       if params[:quote]
-        @reply_to = @topic.posts.find(params[:reply_to_id])
-        @post.text = view_context.forem_quote(@reply_to.text)
+        @post.text = view_context.forem_quote(@reply_to_post.text)
       end
     end
 

--- a/app/views/forem/posts/_reply_to_post.html.erb
+++ b/app/views/forem/posts/_reply_to_post.html.erb
@@ -1,0 +1,23 @@
+<a name='post-<%= post.id %>'></a>
+<div id='post_<%= post.id %>' class='reply_to_post post <%= cycle('odd', 'even') -%>'>
+
+  <div class='user'>
+    <div class='username'>
+      <%= link_to_if Forem.user_profile_links, post.user, [main_app, post.user] %>
+    </div>
+    <div class='icon'><%= forem_avatar(post.user, :size => 60) %></div>
+  </div>
+
+  <div class='contents'>
+    <a href='#post-<%= post.id %>'>
+      <time datetime="<%= post.created_at.to_s(:db) -%>"><%= "#{time_ago_in_words(post.created_at)} #{t("ago")}" %></time>
+    </a>
+    <%= forem_format(post.text) %>
+
+    <% if post.reply_to %>
+      <span class='in_reply_to'>
+        <%= link_to "#{t("forem.post.in_reply_to")} #{post.reply_to.user}", "#post-#{post.reply_to.id}" %>
+      </span>
+    <% end %>
+  </div>
+</div>

--- a/app/views/forem/posts/new.html.erb
+++ b/app/views/forem/posts/new.html.erb
@@ -2,6 +2,16 @@
 
 <h2><%= t("forem.post.new") %></h2>
 
+<% if @reply_to_post %>
+  <div id='posts'>
+    <%= render 'reply_to_post', :post => @reply_to_post %>
+  </div>
+<% else %>
+  <h3 class='topic_subject'>
+    <%= @topic.subject %>
+  </h3>
+<% end %>
+
 <%= simple_form_for [@topic, @post] do |f| %>
   <%= render :partial => "form", :locals => { :f => f } %>
   <%= f.submit t("forem.post.buttons.reply") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,7 +140,7 @@ en:
         reply: Post Reply
         edit: Edit
       created: Your reply has been posted.
-      new: Post reply
+      new: Post reply to
       edit: Edit
       not_created: Your reply could not be posted.
       not_created_topic_locked: You cannot reply to a locked topic.

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -45,6 +45,10 @@ describe "posts" do
       end
 
       context "to an unlocked topic" do
+        it "shows the topic we are replying to" do
+          page.should have_content(topic.posts.first.text)
+        end
+
         it "can post a reply" do
           fill_in "Text", :with => "Witty and insightful commentary."
           click_button "Post Reply"


### PR DESCRIPTION
When replying to a  particular post (pressing "reply" instead of "quote") we should see a the entire post we are replying to on the new post page. When replying to a topic, the topic subject is shown. Includes one new spec.

If this is included in master it will require updating forem themes also to add "clear:both" style to new_post form because it goes directly under the markup of the post we are replying to. That markup uses float style which breaks the new post form layout.
