### PR TITLE
Use Forem.formatter to sanitize input if it has sanitize method. Needed for HTMl/WYSIWYG formatting.

### DIFF
--- a/app/helpers/forem/formatting_helper.rb
+++ b/app/helpers/forem/formatting_helper.rb
@@ -18,7 +18,11 @@ module Forem
     end
 
     def as_sanitized_text(text)
-      sanitize(text, :tags=>%W(p), :attributes=>[])
+      if Forem.formatter.respond_to?(:sanitize)
+        Forem.formatter.sanitize(text)
+      else
+        sanitize(text, :tags=>%W(p), :attributes=>[])
+      end
     end
   end
 end

--- a/spec/helpers/formatting_helper_spec.rb
+++ b/spec/helpers/formatting_helper_spec.rb
@@ -63,6 +63,8 @@ describe Forem::FormattingHelper do
       describe "uses formatter quoting method if exists" do
          subject { helper.as_quoted_text(raw_html) }
          before { Forem.formatter.stub('respond_to?').with(:blockquote).and_return(true) }
+         before { Forem.formatter.stub('respond_to?').with(:sanitize).and_return(false) }
+
          before { Forem.formatter.stub(:blockquote).and_return("> #{markdown}") }
 
          it "quotes the original content" do
@@ -70,6 +72,17 @@ describe Forem::FormattingHelper do
          end
          it {should be_html_safe}
        end
+
+      describe "uses formatter sanitize method if exists" do
+        subject { helper.as_formatted_html(markdown) }
+
+        before { Forem.formatter.stub('respond_to?').with(:blockquote).and_return(false) }
+        before { Forem.formatter.stub('respond_to?').with(:sanitize).and_return(true) }
+        before { Forem.formatter.stub(:sanitize).and_return("sanitized it") }
+
+        it {subject.should == "<p>sanitized it</p>"}
+
+      end
     end
   end
 end

--- a/spec/helpers/formatting_helper_spec.rb
+++ b/spec/helpers/formatting_helper_spec.rb
@@ -62,10 +62,12 @@ describe Forem::FormattingHelper do
 
       describe "uses formatter quoting method if exists" do
          subject { helper.as_quoted_text(raw_html) }
-         before { Forem.formatter.stub('respond_to?').with(:blockquote).and_return(true) }
-         before { Forem.formatter.stub('respond_to?').with(:sanitize).and_return(false) }
+         before {
+           Forem.formatter.stub('respond_to?').with(:blockquote).and_return(true)
+           Forem.formatter.stub('respond_to?').with(:sanitize).and_return(false)
 
-         before { Forem.formatter.stub(:blockquote).and_return("> #{markdown}") }
+           Forem.formatter.stub(:blockquote).and_return("> #{markdown}")
+         }
 
          it "quotes the original content" do
            subject.should == "> #{markdown}"
@@ -76,9 +78,12 @@ describe Forem::FormattingHelper do
       describe "uses formatter sanitize method if exists" do
         subject { helper.as_formatted_html(markdown) }
 
-        before { Forem.formatter.stub('respond_to?').with(:blockquote).and_return(false) }
-        before { Forem.formatter.stub('respond_to?').with(:sanitize).and_return(true) }
-        before { Forem.formatter.stub(:sanitize).and_return("sanitized it") }
+        before {
+          Forem.formatter.stub('respond_to?').with(:blockquote).and_return(false)
+          Forem.formatter.stub('respond_to?').with(:sanitize).and_return(true)
+
+          Forem.formatter.stub(:sanitize).and_return("sanitized it")
+        }
 
         it {subject.should == "<p>sanitized it</p>"}
 


### PR DESCRIPTION
Very basic change: if a formatter has a sanitize method, use it. With a simple spec. 
