### PR TITLE
Can't view topic if current_viewed_at not set

### DIFF
--- a/app/models/forem/concerns/viewable.rb
+++ b/app/models/forem/concerns/viewable.rb
@@ -22,6 +22,8 @@ module Forem
         increment!(:views_count)
 
         # update current viewed at if more than 15 minutes ago
+        if view.current_viewed_at.nil?
+          view.past_viewed_at = view.current_viewed_at = Time.now
         if view.current_viewed_at < 15.minutes.ago
           view.past_viewed_at    = view.current_viewed_at
           view.current_viewed_at = Time.now


### PR DESCRIPTION
I have a number of topics created between the two migrations `add_forem_views` and `add_forem_view_fields`, so `viewed_at` fields for them are nil. Whenever I try to view one of these topics, I get a 'no method < for nil' from Viewable.
