### PR TITLE
bug fix: moderation > work when option not selected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tmp
 *.sw*
 spec/dummy
 *.rbc
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ tmp
 *.sw*
 spec/dummy
 *.rbc
-.idea

--- a/app/controllers/forem/moderation_controller.rb
+++ b/app/controllers/forem/moderation_controller.rb
@@ -10,15 +10,23 @@ module Forem
     end
 
     def posts
-      Post.moderate!(params[:posts] || [])
-      flash[:notice] = t('forem.posts.moderation.success')
+      if params[:posts]
+        Post.moderate!(params[:posts])
+        flash[:notice] = t('forem.posts.moderation.success')
+      else
+        flash[:alert] = t("forem.moderation.failure")
+      end
       redirect_to :back
     end
 
     def topic
       topic = forum.topics.find(params[:topic_id])
-      topic.moderate!(params[:topic][:moderation_option])
-      flash[:notice] = t("forem.topic.moderation.success")
+      if params[:topic] && params[:topic][:moderation_option]
+        topic.moderate!(params[:topic][:moderation_option])
+        flash[:notice] = t("forem.topic.moderation.success")
+      else
+        flash[:alert] = t("forem.moderation.failure")
+      end
       redirect_to :back
     end
 

--- a/app/models/forem/post.rb
+++ b/app/models/forem/post.rb
@@ -77,8 +77,10 @@ module Forem
       def moderate!(posts)
         posts.each do |post_id, moderation|
           # We use find_by_id here just in case a post has been deleted.
-          post = Post.find_by_id(post_id)
-          post.send("#{moderation[:moderation_option]}!") if post
+          if moderation[:moderation_option]
+            post = Post.find_by_id(post_id)
+            post.send("#{moderation[:moderation_option]}!") if post
+          end
         end
       end
     end

--- a/app/models/forem/post.rb
+++ b/app/models/forem/post.rb
@@ -77,9 +77,8 @@ module Forem
       def moderate!(posts)
         posts.each do |post_id, moderation|
           # We use find_by_id here just in case a post has been deleted.
-          if moderation[:moderation_option]
-            post = Post.find_by_id(post_id)
-            post.send("#{moderation[:moderation_option]}!") if post
+          if moderation[:moderation_option] && (post = Post.find_by_id(post_id))
+            post.send("#{moderation[:moderation_option]}!")
           end
         end
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,7 @@ en:
         pending_review: This post is currently pending review. Only the user who posted it and moderators can view it.
     moderation:
       title: "Moderation tools for %{forum}"
+      failure: Please select an option for moderation.
   helpers:
     submit:
       forum:

--- a/spec/requests/moderation/post_moderation_spec.rb
+++ b/spec/requests/moderation/post_moderation_spec.rb
@@ -59,6 +59,13 @@ describe "moderation" do
         flash_notice!("The selected posts have been moderated.")
         post.user.reload.forem_state.should == "approved"
       end
+      it "when moderation option not selected" do
+        visit forum_topic_path(forum, topic)
+        click_button "Moderate"
+
+        flash_alert!("Please select an option for moderation.")
+        post.user.reload.forem_state.should == "pending_review"
+      end
     end
   end
 end

--- a/spec/requests/moderation/topic_moderation_spec.rb
+++ b/spec/requests/moderation/topic_moderation_spec.rb
@@ -26,7 +26,18 @@ describe "moderation" do
           click_button "Moderate"
         end
         flash_notice!("The selected topic has been moderated.")
-        page.should_not have_content("This topic is currently pending review.")
+        page.should have_no_content("This topic is currently pending review.")
+      end
+
+      context "when moderation option not selected" do
+        it "should show message" do
+          visit forum_topic_path(forum, topic)
+          within("#topic_moderation") do
+            click_button "Moderate"
+          end
+          flash_alert!("Please select an option for moderation.")
+          page.should have_content("This topic is currently pending review.")
+        end
       end
     end
   end

--- a/spec/requests/topics_spec.rb
+++ b/spec/requests/topics_spec.rb
@@ -112,21 +112,10 @@ describe "topics" do
         it "increments a view" do
           # register a view
           visit forum_topic_path(forum, topic)
-
-          # expect does not work as expected.
-          # the view object is not reloaded when it's re-checked, but cached instead
-          # Therefore we cannot do this:
-          #
-          # expect do
-          #   visit forum_topic_path(forum, topic)
-          # end.to change(view.reload, :count)
-          #
-          # But instead must go long-form:
-
           view = ::Forem::View.last
-          view.count.should eql(1)
-          visit forum_topic_path(forum, topic)
-          view.reload.count.should eql(2)
+          expect do
+            visit forum_topic_path(forum, topic)
+          end.to change{ view.reload.count }.by(1)
         end
       end
     end


### PR DESCRIPTION
bug description:
when forum admin clicks "Moderate" without selecting 'Approve' or 'Spam', then
for topic: 500 error occurs (params[:topic] is nil)
for posts: nothing happens but success message is shown
