### PR TITLE
Removed protocol from gravatar url to allow https.

### DIFF
--- a/app/helpers/forem/posts_helper.rb
+++ b/app/helpers/forem/posts_helper.rb
@@ -18,7 +18,7 @@ module Forem
       options[:s] = options.delete(:size) || 60
       options[:d] = options.delete(:default) || default_gravatar
       options.delete(:d) unless options[:d]
-      "http://www.gravatar.com/avatar/#{md5}?#{options.to_param}"
+      "//www.gravatar.com/avatar/#{md5}?#{options.to_param}"
     end
 
     def default_gravatar

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -10,7 +10,7 @@ module Forem
         let(:opts) { {} }
 
         it 'includes the default size' do
-          expected = "http://www.gravatar.com/avatar/#{email_hash}?s=60"
+          expected = "//www.gravatar.com/avatar/#{email_hash}?s=60"
           helper.avatar_url(email, opts).should eq(expected)
         end
       end
@@ -19,7 +19,7 @@ module Forem
         let(:opts) { {:size => 99} }
 
         it 'overwrites the default size' do
-          expected = "http://www.gravatar.com/avatar/#{email_hash}?s=99"
+          expected = "//www.gravatar.com/avatar/#{email_hash}?s=99"
           helper.avatar_url(email, opts).should eq(expected)
         end
       end
@@ -28,7 +28,7 @@ module Forem
         let(:opts) { {:default => 'mm'} }
 
         it 'includes a default parameter' do
-          expected = "http://www.gravatar.com/avatar/#{email_hash}?d=mm&s=60"
+          expected = "//www.gravatar.com/avatar/#{email_hash}?d=mm&s=60"
           helper.avatar_url(email, opts).should eq(expected)
         end
       end
@@ -37,7 +37,7 @@ module Forem
         let(:opts) { {:default => 'mm', :size => '99'} }
 
         it 'includes a default parameter and overwrites the default size' do
-          expected = "http://www.gravatar.com/avatar/#{email_hash}?d=mm&s=99"
+          expected = "//www.gravatar.com/avatar/#{email_hash}?d=mm&s=99"
           helper.avatar_url(email, opts).should eq(expected)
         end
       end


### PR DESCRIPTION
I run the forum on a server using https, and the gravatar images were giving security warnings.  I've made the urls protocol relative as per: http://paulirish.com/2010/the-protocol-relative-url/ which has removed the security warnings for me.
