### PR TITLE
Updated ssl Gravatar links to use https://secure instead of https://www

### DIFF
--- a/app/helpers/forem/posts_helper.rb
+++ b/app/helpers/forem/posts_helper.rb
@@ -18,7 +18,7 @@ module Forem
       options[:s] = options.delete(:size) || 60
       options[:d] = options.delete(:default) || default_gravatar
       options.delete(:d) unless options[:d]
-      "//www.gravatar.com/avatar/#{md5}?#{options.to_param}"
+      "#{request.ssl? ? 'https://secure' : 'http://www'}.gravatar.com/avatar/#{md5}?#{options.to_param}"
     end
 
     def default_gravatar

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -10,7 +10,7 @@ module Forem
         let(:opts) { {} }
 
         it 'includes the default size' do
-          expected = "//www.gravatar.com/avatar/#{email_hash}?s=60"
+          expected = "http://www.gravatar.com/avatar/#{email_hash}?s=60"
           helper.avatar_url(email, opts).should eq(expected)
         end
       end
@@ -19,7 +19,7 @@ module Forem
         let(:opts) { {:size => 99} }
 
         it 'overwrites the default size' do
-          expected = "//www.gravatar.com/avatar/#{email_hash}?s=99"
+          expected = "http://www.gravatar.com/avatar/#{email_hash}?s=99"
           helper.avatar_url(email, opts).should eq(expected)
         end
       end
@@ -28,7 +28,7 @@ module Forem
         let(:opts) { {:default => 'mm'} }
 
         it 'includes a default parameter' do
-          expected = "//www.gravatar.com/avatar/#{email_hash}?d=mm&s=60"
+          expected = "http://www.gravatar.com/avatar/#{email_hash}?d=mm&s=60"
           helper.avatar_url(email, opts).should eq(expected)
         end
       end
@@ -37,7 +37,17 @@ module Forem
         let(:opts) { {:default => 'mm', :size => '99'} }
 
         it 'includes a default parameter and overwrites the default size' do
-          expected = "//www.gravatar.com/avatar/#{email_hash}?d=mm&s=99"
+          expected = "http://www.gravatar.com/avatar/#{email_hash}?d=mm&s=99"
+          helper.avatar_url(email, opts).should eq(expected)
+        end
+      end
+
+      context 'with any email and ssl' do
+        let(:opts) { {} }
+
+        it 'should have the secure url' do
+          helper.request.env['HTTPS'] = 'on'
+          expected = "https://secure.gravatar.com/avatar/#{email_hash}?s=60"
           helper.avatar_url(email, opts).should eq(expected)
         end
       end


### PR DESCRIPTION
Another update to a change I made recently.  I just discovered that Gravatar prefers https://secure than https://www, so I added code to conditionally add one or the other depending on request.ssl?

New test added to test SSL Gravatar URLs.
