### PR TITLE
Added moderation and subscription_mailer folders to view generator

### DIFF
--- a/lib/generators/forem/views_generator.rb
+++ b/lib/generators/forem/views_generator.rb
@@ -11,7 +11,9 @@ module Forem
         view_directory :admin
         view_directory :categories
         view_directory :forums
+        view_directory :moderation
         view_directory :posts
+        view_directory :subscription_mailer
         view_directory :topics
       end
 


### PR DESCRIPTION
When I was modifying views I noticed the moderation folder wasn't generated. Figured I might as well add the subscription_mailer views as well.
