### PR TITLE
Config engine to load decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ All of Forem’s business logic (models, controllers, helpers, etc) can easily b
 Standard practice for including such changes in your application or extension is to create a file within the relevant app/models or app/controllers directory with the original class name with _decorator appended.
 
 ### Adding a custom method to the Post model:
-    # app/models/forem/post_decorator.rb
+    # app/decorators/models/forem/post_decorator.rb
 
     Forem::Post.class_eval do
       def some_method
@@ -107,7 +107,7 @@ Standard practice for including such changes in your application or extension is
     end
 
 ### Adding a custom method to the PostsController:
-    # app/controllers/forem/posts_controller_decorator.rb
+    # app/decorators/controllers/forem/posts_controller_decorator.rb
 
     Forem::PostsController.class_eval do
       def some_action

--- a/README.md
+++ b/README.md
@@ -83,13 +83,39 @@ If you would like to add auto discovery links for the built in forum Atom feeds,
 
     <%= forem_atom_auto_discovery_link_tag %>
 
-## Customisation
+## Views Customisation
 
 If you want to customise Forem, you can copy over the views using the (Devise-inspired) `forem:views` generator:
 
     rails g forem:views
 
 You will then be able to edit the forem views inside the `app/views/forem` of your application. These views will take precedence over those in the engine.
+
+## Extending Classes
+
+All of Forem’s business logic (models, controllers, helpers, etc) can easily be extended / overridden to meet your exact requirements using standard Ruby idioms.
+
+Standard practice for including such changes in your application or extension is to create a file within the relevant app/models or app/controllers directory with the original class name with _decorator appended.
+
+### Adding a custom method to the Post model:
+    # app/models/post_decorator.rb
+
+    Forem::Post.class_eval do
+      def some_method
+        ...
+      end
+    end
+
+### Adding a custom method to the PostsController:
+    # app/controllers/posts_controller_decorator.rb
+
+    Forem::PostsController.class_eval do
+      def some_action
+        ...
+      end
+    end
+
+The exact same format can be used to redefine an existing method.
 
 ## Translations
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ All of Forem’s business logic (models, controllers, helpers, etc) can easily b
 Standard practice for including such changes in your application or extension is to create a file within the relevant app/models or app/controllers directory with the original class name with _decorator appended.
 
 ### Adding a custom method to the Post model:
-    # app/models/post_decorator.rb
+    # app/models/forem/post_decorator.rb
 
     Forem::Post.class_eval do
       def some_method
@@ -107,7 +107,7 @@ Standard practice for including such changes in your application or extension is
     end
 
 ### Adding a custom method to the PostsController:
-    # app/controllers/posts_controller_decorator.rb
+    # app/controllers/forem/posts_controller_decorator.rb
 
     Forem::PostsController.class_eval do
       def some_action

--- a/lib/forem/engine.rb
+++ b/lib/forem/engine.rb
@@ -9,8 +9,13 @@ module ::Forem
       end
     end
 
-    # Fix for #88
-    config.to_prepare do
+    def self.activate
+
+      Dir.glob(File.join(File.dirname(__FILE__), "../app/**/*_decorator*.rb")) do |c|
+        Rails.configuration.cache_classes ? require(c) : load(c)
+      end
+
+      # Fix for #88
       if Forem.user_class
         Forem.user_class.send :extend, Forem::Autocomplete
 
@@ -25,6 +30,8 @@ module ::Forem
       # add forem helpers to main application
       ::ApplicationController.send :helper, Forem::Engine.helpers
     end
+
+    config.to_prepare &method(:activate).to_proc
   end
 end
 


### PR DESCRIPTION
While extending forem classes we need to require decorators in main app's application.rb. Now with this code they will automatically required when engine get loaded.  
