### PR TITLE
add forem proxy in form builder missed in change of #274

### DIFF
--- a/app/views/forem/posts/_post.html.erb
+++ b/app/views/forem/posts/_post.html.erb
@@ -16,7 +16,7 @@
           <% if local_assigns[:mass_moderation] %>
             <%= render "forem/posts/moderation_tools", :post => post %>
           <% else %>
-            <%= form_tag forum_moderate_posts_path(post.topic.forum), :method => :put do %>
+            <%= form_tag forem.forum_moderate_posts_path(post.topic.forum), :method => :put do %>
               <%= render "forem/posts/moderation_tools", :post => post %>
             <% end %>
           <% end %>


### PR DESCRIPTION
all routes / form builders were prefixed with forem routes proxy in fix of #274. so one form builder is _post.html.erb file missed that change. updated that one.
