### PR TITLE
[Javascript] Fixed autocompletion remote request failure for urls with leading slashes

### DIFF
--- a/app/assets/javascripts/forem.js.erb
+++ b/app/assets/javascripts/forem.js.erb
@@ -6,4 +6,5 @@ var Forem = {};
   path = path.respond_to?(:spec) ? path.spec.to_s : path
 %>
 
-Forem.base_path = <%= path.inspect %>
+/* Strips leading slashes from base_path */
+Forem.base_path = <%= path.inspect.sub(/\A\/*/, '') %>

--- a/app/assets/javascripts/forem.js.erb
+++ b/app/assets/javascripts/forem.js.erb
@@ -7,4 +7,4 @@ var Forem = {};
 %>
 
 /* Strips leading slashes from base_path */
-Forem.base_path = <%= path.inspect.sub(/\A\/*/, '') %>
+Forem.base_path = <%= path.inspect.sub!(/\A\/*/, '') %>

--- a/app/assets/javascripts/forem.js.erb
+++ b/app/assets/javascripts/forem.js.erb
@@ -4,7 +4,8 @@ var Forem = {};
   path = Rails.application.routes.named_routes[:forem].path
   # Rails 3.2 returns a Journey::Path::Pattern object, Rails 3.1 an actual path.
   path = path.respond_to?(:spec) ? path.spec.to_s : path
+  # Strips leading slashes from base_path
+  path = path.sub(/\A\/*/, '')
 %>
 
-/* Strips leading slashes from base_path */
-Forem.base_path = <%= path.inspect.sub!(/\A\/*/, '') %>
+Forem.base_path = <%= path.inspect %>

--- a/app/assets/javascripts/forem/admin/members.js
+++ b/app/assets/javascripts/forem/admin/members.js
@@ -6,7 +6,7 @@
 (function($) {
   $(document).ready(function() {
     group_id = $('#add_member').data('group-id');
-    $('#new_member').autocomplete({source: 'http://' + window.location.host + Forem.base_path + '/admin/users/autocomplete'})
+    $('#new_member').autocomplete({source: Forem.base_path + 'admin/users/autocomplete'})
 
     $("#new_member").bind("autocompleteselect", function(event, ui) {
       $("#add_member").attr('disabled', false)

--- a/app/assets/javascripts/forem/admin/members.js
+++ b/app/assets/javascripts/forem/admin/members.js
@@ -6,7 +6,7 @@
 (function($) {
   $(document).ready(function() {
     group_id = $('#add_member').data('group-id');
-    $('#new_member').autocomplete({source: Forem.base_path + 'admin/users/autocomplete'})
+    $('#new_member').autocomplete({source: 'http://' + window.location.host + Forem.base_path + '/admin/users/autocomplete'})
 
     $("#new_member").bind("autocompleteselect", function(event, ui) {
       $("#add_member").attr('disabled', false)

--- a/app/assets/javascripts/forem/admin/members.js
+++ b/app/assets/javascripts/forem/admin/members.js
@@ -6,7 +6,7 @@
 (function($) {
   $(document).ready(function() {
     group_id = $('#add_member').data('group-id');
-    $('#new_member').autocomplete({source: Forem.base_path + '/admin/users/autocomplete'})
+    $('#new_member').autocomplete({source: Forem.base_path + 'admin/users/autocomplete'})
 
     $("#new_member").bind("autocompleteselect", function(event, ui) {
       $("#add_member").attr('disabled', false)

--- a/app/assets/javascripts/forem/admin/members.js
+++ b/app/assets/javascripts/forem/admin/members.js
@@ -6,7 +6,7 @@
 (function($) {
   $(document).ready(function() {
     group_id = $('#add_member').data('group-id');
-    $('#new_member').autocomplete({source: Forem.base_path + 'admin/users/autocomplete'})
+    $('#new_member').autocomplete({source: Forem.base_path + '/admin/users/autocomplete'})
 
     $("#new_member").bind("autocompleteselect", function(event, ui) {
       $("#add_member").attr('disabled', false)


### PR DESCRIPTION
Fixed autocompletion when Forem.base_path started with leading slashes which made the remote call not te contain host's url, leading to request failures.

Main reason was because remote calls failed when working with '/' as a base path.
