### PR TITLE
Add an initializer to precompile a javascript asset...

### DIFF
--- a/lib/forem/engine.rb
+++ b/lib/forem/engine.rb
@@ -28,6 +28,14 @@ module ::Forem
 
       # add forem helpers to main application
       ::ApplicationController.send :helper, Forem::Engine.helpers
+
+    end
+
+    # Precompile any assets included straight in certain pges
+    initializer "forem.assets.precompile", :group => :all do |app|
+      app.config.assets.precompile += %w[
+        forem/admin/members.js
+      ]
     end
   end
 end


### PR DESCRIPTION
This was failing in prroduction if you tried to visit the members page.  The members page still acts funny, but this makes it at least visitable :)
