### PR TITLE
Problem using Admin as #user_class

### DIFF
--- a/app/models/forem/group.rb
+++ b/app/models/forem/group.rb
@@ -3,7 +3,7 @@ module Forem
     validates :name, :presence => true
 
     has_many :memberships
-    has_many :members, :through => :memberships, :class_name => Forem.user_class.to_s
+    has_many :members, :through => :memberships, :class_name => Forem.user_class_string
 
     attr_accessible :name
 

--- a/app/models/forem/membership.rb
+++ b/app/models/forem/membership.rb
@@ -1,7 +1,7 @@
 module Forem
   class Membership < ActiveRecord::Base
     belongs_to :group
-    belongs_to :member, :class_name => Forem.user_class.to_s
+    belongs_to :member, :class_name => Forem.user_class_string
 
     attr_accessible :member_id, :group_id
   end

--- a/app/models/forem/post.rb
+++ b/app/models/forem/post.rb
@@ -20,7 +20,7 @@ module Forem
     attr_accessible :text, :reply_to_id
 
     belongs_to :topic
-    belongs_to :user,     :class_name => Forem.user_class.to_s
+    belongs_to :user,     :class_name => Forem.user_class_string
     belongs_to :reply_to, :class_name => "Post"
 
     has_many :replies, :class_name  => "Post",

--- a/app/models/forem/subscription.rb
+++ b/app/models/forem/subscription.rb
@@ -1,7 +1,7 @@
 module Forem
   class Subscription < ActiveRecord::Base
     belongs_to :topic
-    belongs_to :subscriber, :class_name => Forem.user_class.to_s
+    belongs_to :subscriber, :class_name => Forem.user_class_string
 
     validates :subscriber_id, :presence => true
 

--- a/app/models/forem/topic.rb
+++ b/app/models/forem/topic.rb
@@ -26,7 +26,7 @@ module Forem
     attr_accessible :subject, :posts_attributes, :pinned, :locked, :hidden, :forum_id, :as => :admin
 
     belongs_to :forum
-    belongs_to :user, :class_name => Forem.user_class.to_s
+    belongs_to :user, :class_name => Forem.user_class_string
     has_many   :subscriptions
     has_many   :posts, :dependent => :destroy, :order => "forem_posts.created_at ASC"
 

--- a/app/models/forem/view.rb
+++ b/app/models/forem/view.rb
@@ -3,7 +3,7 @@ module Forem
     before_create :set_viewed_at_to_now
 
     belongs_to :viewable, :polymorphic => true
-    belongs_to :user, :class_name => Forem.user_class.to_s
+    belongs_to :user, :class_name => Forem.user_class_string
 
     validates :viewable_id, :viewable_type, :presence => true
     attr_accessible :user, :current_viewed_at, :count

--- a/lib/forem.rb
+++ b/lib/forem.rb
@@ -8,8 +8,8 @@ require 'workflow'
 
 module Forem
   mattr_accessor :user_class, :theme, :formatter, :default_gravatar, :default_gravatar_image,
-                 :user_profile_links, :email_from_address, :autocomplete_field,
-                 :avatar_user_method, :per_page, :sign_in_path, :moderate_first_post
+    :user_profile_links, :email_from_address, :autocomplete_field,
+    :avatar_user_method, :per_page, :sign_in_path, :moderate_first_post
 
 
   class << self
@@ -29,9 +29,17 @@ module Forem
     def user_class
       if @@user_class.is_a?(Class)
         raise "You can no longer set Forem.user_class to be a class. Please use a string instead.\n\n " +
-              "See https://github.com/radar/forem/issues/88 for more information."
+          "See https://github.com/radar/forem/issues/88 for more information."
       elsif @@user_class.is_a?(String)
-        @@user_class.constantize
+        user_class_string.constantize
+      end
+    end
+
+    def user_class_string
+      if @@user_class.is_a?(Class)
+        @@user_class.to_s
+      elsif @@user_class.is_a?(String)
+        "::#{@@user_class.gsub(/^::/,'')}"
       end
     end
   end

--- a/spec/lib/generators/forem/dummy/dummy_generator.rb
+++ b/spec/lib/generators/forem/dummy/dummy_generator.rb
@@ -48,6 +48,7 @@ module Forem
       template "config/initializers/devise.rb", "#{dummy_path}/config/initializers/devise.rb", :force => true
       template "config/initializers/forem.rb", "#{dummy_path}/config/initializers/forem.rb", :force => true
       template "db/migrate/1_create_users.rb", "#{dummy_path}/db/migrate/1_create_users.rb", :force => true
+      template "db/migrate/2_create_admins.rb", "#{dummy_path}/db/migrate/2_create_admins.rb", :force => true
       template "Rakefile", "#{dummy_path}/Rakefile", :force => true
       inject_into_file "#{dummy_path}/config/environments/test.rb",
                   "\n  config.action_mailer.default_url_options = { :host => 'www.example.com' }\n",

--- a/spec/lib/generators/forem/dummy/templates/app/models/admin.rb
+++ b/spec/lib/generators/forem/dummy/templates/app/models/admin.rb
@@ -1,0 +1,2 @@
+class Admin < ActiveRecord::Base
+end

--- a/spec/lib/generators/forem/dummy/templates/db/migrate/2_create_admins.rb
+++ b/spec/lib/generators/forem/dummy/templates/db/migrate/2_create_admins.rb
@@ -1,0 +1,8 @@
+class CreateAdmins < ActiveRecord::Migration
+  create_table :admins, :force => true do |t|
+    t.string  :name,   :default => "",    :null => false
+    t.string  :email,  :default => "",    :null => false
+  end
+
+  add_index :admins, :email, :unique => true
+end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+# There is no User class within Forem; this is testing the dummy application's class
+# More specifically, it is testing the methods provided by Forem::DefaultPermissions
+
+describe Admin do
+
+  before(:each) do
+    @original_class_name = Forem.user_class
+    Forem.user_class = "Admin"
+  end
+
+  after(:each) do
+    Forem.user_class = @original_class_name.to_s
+  end
+
+  context "Without top level reference" do
+    before(:each) do
+      Forem.user_class = "Admin"
+    end
+
+    it "return class constant" do
+      assert_equal Admin, Forem.user_class
+    end
+
+    it "it return class as srting" do
+      assert_equal "::Admin", Forem.user_class_string
+    end
+  end
+
+  context "With top level reference" do
+    before(:each) do
+      Forem.user_class = "::Admin"
+    end
+
+    it "return class constant" do
+      assert_equal Admin, Forem.user_class
+    end
+
+    it "it return class as srting" do
+      assert_equal "::Admin", Forem.user_class_string
+    end
+  end
+end


### PR DESCRIPTION
Recently i faced a problem, trying to specify "Admin" as Forem.user_class.
the error i got was something

Undefined method 'scope' for Forem::Admin module.

The solution I end up with is following:

String representing constant name should contain TopLevel reference. 
In order to keep backward compatibility, class_name_string method was implemented.

Tests are added.

Check out commit.
