### PR TITLE
Namespaced models can now be used with Forem#user_class.

### DIFF
--- a/lib/forem.rb
+++ b/lib/forem.rb
@@ -31,7 +31,11 @@ module Forem
         raise "You can no longer set Forem.user_class to be a class. Please use a string instead.\n\n " +
               "See https://github.com/radar/forem/issues/88 for more information."
       elsif @@user_class.is_a?(String)
-        Object.const_get(@@user_class)
+        begin
+          Object.const_get(@@user_class)
+        rescue NameError
+          @@user_class.constantize
+        end
       end
     end
   end

--- a/spec/lib/generators/forem/dummy/templates/app/models/refunery/yooser.rb
+++ b/spec/lib/generators/forem/dummy/templates/app/models/refunery/yooser.rb
@@ -1,0 +1,5 @@
+module Refunery
+  class Yooser < ActiveRecord::Base
+
+  end
+end

--- a/spec/lib/generators/forem/dummy/templates/db/migrate/3_create_refunery_yoosers.rb
+++ b/spec/lib/generators/forem/dummy/templates/db/migrate/3_create_refunery_yoosers.rb
@@ -1,0 +1,8 @@
+class CreateRefuneryYoosers < ActiveRecord::Migration
+  create_table :refunery_yoosers, :force => true do |t|
+    t.string  :name,   :default => "",    :null => false
+    t.string  :email,  :default => "",    :null => false
+  end
+
+  add_index :refunery_yoosers, :email, :unique => true
+end

--- a/spec/models/refunery_yooser_spec.rb
+++ b/spec/models/refunery_yooser_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+# There is no User class within Forem; this is testing the dummy application's class
+# More specifically, it is testing the methods provided by Forem::DefaultPermissions
+#
+# Regression test for #329 and #335
+
+describe Refunery::Yooser do
+
+  before(:each) do
+    @original_class_name = Forem.user_class
+    Forem.user_class = "Refunery::Yooser"
+  end
+
+  after(:each) do
+    Forem.user_class = @original_class_name.to_s
+  end
+
+  context "Without top level reference" do
+    before(:each) do
+      Forem.user_class = "Refunery::Yooser"
+    end
+
+    it "return class constant" do
+      assert_equal Refunery::Yooser, Forem.user_class
+    end
+
+    it "it return class as string" do
+      assert_equal "Refunery::Yooser", Forem.user_class.to_s
+    end
+  end
+
+  context "With top level reference" do
+    before(:each) do
+      Forem.user_class = "Refunery::Yooser"
+    end
+
+    it "return class constant" do
+      assert_equal Refunery::Yooser, Forem.user_class
+    end
+
+    it "it return class as string" do
+      assert_equal "Refunery::Yooser", Forem.user_class.to_s
+    end
+  end
+end


### PR DESCRIPTION
Fixes #335 (see issue for details)
Also fixes #329
