### PR TITLE
Add default_scope to order forums alphabetically

### DIFF
--- a/app/models/forem/forum.rb
+++ b/app/models/forem/forum.rb
@@ -20,6 +20,8 @@ module Forem
 
     alias_attribute :name, :title
 
+    default_scope order('title ASC')
+
     def last_post_for(forem_user)
       if forem_user && (forem_user.forem_admin? || moderator?(forem_user))
         posts.last


### PR DESCRIPTION
Before this commit, forums were sorted by latest viewed at the bottom,
which caused much user confusion.
