### PR TITLE
Latest post

### DIFF
--- a/app/helpers/forem/topics_helper.rb
+++ b/app/helpers/forem/topics_helper.rb
@@ -3,7 +3,7 @@ module Forem
     def link_to_latest_post(topic)
       post = relevant_posts(topic).last
       text = "#{time_ago_in_words(post.created_at)} #{t("ago_by")} #{post.user}"
-      link_to text, forem.forum_topic_path(post.topic.forum, post.topic, :anchor => "post-#{post.id}")
+      link_to text, forem.forum_topic_path(post.topic.forum, post.topic, :anchor => "post-#{post.id}", :page => topic.last_page)
     end
 
     def new_since_last_view_text(topic)


### PR DESCRIPTION
Before this pull request, clicking on the Latest post in a forum would correctly put the post's ID in the URL for the browser to scroll to, but it neglected to put the correct page in the URL (and of course the browser can't scroll to a post that isn't on that page). This pull request adds the correct (last) page to the URL so that clicking Last post now takes you to the last page and scrolls to the post.
