### PR TITLE
Fix Gemoji with latest gem

### DIFF
--- a/app/helpers/forem/application_helper.rb
+++ b/app/helpers/forem/application_helper.rb
@@ -34,16 +34,18 @@ module Forem
       end
     end
 
-    def forem_atom_auto_discovery_link_tag  
+    def forem_atom_auto_discovery_link_tag
       if controller_name == "topics" && action_name == "show"
         auto_discovery_link_tag(:atom)
       end
     end
 
     def forem_emojify(content)
+      require 'emoji'
+
       h(content).to_str.gsub(/:([a-z0-9\+\-_]+):/) do |match|
-        if Emoji.names.include?($1)
-          '<img alt="' + $1 + '" height="20" src="' + asset_path("emoji/#{$1}.png") + '" style="vertical-align:middle" width="20" />'
+        if ::Emoji.names.include?($1)
+          '<img alt="' + $1 + '" height="20" src="' + "/images/emoji/#{$1}.png" + '" style="vertical-align:middle" width="20" />'
         else
           match
         end

--- a/forem.gemspec
+++ b/forem.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'forem-redcarpet', '1.0.0'
   s.add_dependency 'workflow', '0.8.0'
   s.add_dependency 'friendly_id', '~> 4.0'
-  s.add_dependency 'gemoji', '= 1.1.2'
+  s.add_dependency 'gemoji'
 end


### PR DESCRIPTION
Fixes #340. The latest Gemoji gem's recommended usage is to serve the images from Public rather than Assets because the hundreds of images slow down asset precompilation.

This commit updates the gem, and changes the helper to use the public path.
- I have hardcoded the `/images/emoji` bit of the path, I'm not sure if this is the best way or if there is a rails helper to do it. Would the public directory ever move? Would people ever put images in a folder other than images? I've only used the asset pipeline before so I'm not sure if there are any gotchas here to be aware of.
- There is a rake task that needs adding to the app's rakefile and running to copy the images from Gemoji to public/images. See the [Gemoji readme](https://github.com/github/gemoji) for info. It may be worthwhile making the rake task run automatically on Forem install, not sure how that would work. Currently having to edit the `Rakefile` and run a task doesn't seem ideal, but it might not be the end of the world.
- I had to add a `require` for Gemoji and change the class slightly as Rails wasn't finding it, I'm not sure why, perhaps the gem changed its structure slightly or I'm missing something. What I've done works, I'm just not certain it's the Best Way.
