### PR TITLE
Making "title" the alias instead of "name"

### DIFF
--- a/app/models/forem/forum.rb
+++ b/app/models/forem/forum.rb
@@ -5,7 +5,7 @@ module Forem
     include Forem::Concerns::Viewable
 
     extend FriendlyId
-    friendly_id :title, :use => :slugged
+    friendly_id :name, :use => :slugged
 
     belongs_to :category
 
@@ -14,14 +14,14 @@ module Forem
     has_many :moderators, :through => :moderator_groups, :source => :group
     has_many :moderator_groups
 
-    validates :category, :title, :description, :presence => true
+    validates :category, :name, :description, :presence => true
 
     attr_accessible :category_id, :title, :name, :description, :moderator_ids
 
-    alias_attribute :name, :title
+    alias_attribute :title, :name
 
     # Fix for #339
-    default_scope order('title ASC')
+    default_scope order('name ASC')
 
     def last_post_for(forem_user)
       if forem_user && (forem_user.forem_admin? || moderator?(forem_user))

--- a/db/migrate/20121203093719_rename_title_to_name_on_forem_forums.rb
+++ b/db/migrate/20121203093719_rename_title_to_name_on_forem_forums.rb
@@ -1,0 +1,5 @@
+class RenameTitleToNameOnForemForums < ActiveRecord::Migration
+  def up
+    rename_column :forem_forums, :title, :name
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,8 +2,8 @@ Forem::Category.create(:name => 'General')
 
 user = Forem.user_class.first
 unless user.nil?
-  forum = Forem::Forum.find_or_create_by_title( :category_id => Forem::Category.first.id, 
-                               :title => "Default",
+  forum = Forem::Forum.find_or_create_by_name(:category_id => Forem::Category.first.id, 
+                               :name => "Default",
                                :description => "Default forem created by install")
 
   post = Forem::Post.find_or_initialize_by_text("Hello World")

--- a/spec/models/forum_spec.rb
+++ b/spec/models/forum_spec.rb
@@ -8,12 +8,12 @@ describe Forem::Forum do
   end
 
   it "is scoped by default" do
-    Forem::Forum.scoped.to_sql.should =~ /ORDER BY title ASC/
+    Forem::Forum.scoped.to_sql.should =~ /ORDER BY name ASC/
   end
 
   describe "validations" do
-    it "requires a title" do
-      forum.title = nil
+    it "requires a name" do
+      forum.name = nil
       forum.should_not be_valid
     end
 


### PR DESCRIPTION
In relation to https://github.com/radar/forem/commit/79ac5972a915b5de24ed382b0cf2d4740e64f186 - might we make `title` the alias instead? Will gladly submit a pull request changing all instances of `title` to `name` and reversing 79ac597.

That way nobody would get angry right? Then in a couple of years we could just remove the alias altogether and live happily ever after.
