### PR TITLE
Link in forum description

### DIFF
--- a/app/views/forem/forums/_forum.html.erb
+++ b/app/views/forem/forums/_forum.html.erb
@@ -2,7 +2,7 @@
   <tr class="forum <%= cycle("odd", "even") %>">
     <td>
       <%= link_to forem_emojify(forum.title), forem.forum_path(forum), :class => "title" %>
-      <div class='description'><%= forem_emojify(forum.description) %></div>
+      <div class='description'><%= forem_format(forum.description) %></div>
       <%= t('forem.forums.index.last_post') -%>
       <span class='last_post'>
           <% if last_post = forum.last_post_for(forem_user) -%>

--- a/spec/requests/forums_spec.rb
+++ b/spec/requests/forums_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'forem/formatters/redcarpet'
 
 describe "forums" do
   let!(:forum) { FactoryGirl.create(:forum) }
@@ -9,6 +10,21 @@ describe "forums" do
       page.should have_content("Welcome to Forem!")
       within(".description") do
         page.should have_content("A placeholder forum.")
+      end
+    end
+  end
+
+  # Regression test for #352
+  context "can include Markdown within a forum's description" do
+    before { Forem.formatter = Forem::Formatters::Redcarpet }
+    after { Forem.formatter = nil }
+
+    it "includes a strong tag in a description" do
+
+      forum.update_column(:description, "The **best** forum!")
+      visit forums_path
+      within(".forum") do
+        assert find(".description").has_css?("strong")
       end
     end
   end


### PR DESCRIPTION
I'd like to add a link to the forum description. Using GFM successfully.  No luck getting a link to parse in a forum description tho.  Must be missing something.  Help?
