### PR TITLE
Update CanCan to 1.6.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
   remote: .
   specs:
     forem (1.0.0.beta1)
-      cancan (= 1.6.7)
+      cancan (= 1.6.8)
       forem-redcarpet (= 1.0.0)
       friendly_id (~> 4.0)
       gemoji (= 1.1.2)
@@ -51,7 +51,7 @@ GEM
     bcrypt-ruby (3.0.1)
     blankslate (3.1.2)
     builder (3.0.4)
-    cancan (1.6.7)
+    cancan (1.6.8)
     capybara (1.1.3)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)

--- a/app/controllers/forem/categories_controller.rb
+++ b/app/controllers/forem/categories_controller.rb
@@ -1,6 +1,6 @@
 module Forem
   class CategoriesController < Forem::ApplicationController
     helper 'forem/forums'
-    load_and_authorize_resource :class => Forem::Category
+    load_and_authorize_resource :class => 'Forem::Category'
   end
 end

--- a/app/controllers/forem/categories_controller.rb
+++ b/app/controllers/forem/categories_controller.rb
@@ -1,6 +1,6 @@
 module Forem
   class CategoriesController < Forem::ApplicationController
     helper 'forem/forums'
-    load_and_authorize_resource
+    load_and_authorize_resource :class => Forem::Category
   end
 end

--- a/app/controllers/forem/forums_controller.rb
+++ b/app/controllers/forem/forums_controller.rb
@@ -1,6 +1,6 @@
 module Forem
   class ForumsController < Forem::ApplicationController
-    load_and_authorize_resource :only => :show
+    load_and_authorize_resource :class => 'Forem::Forum', :only => :show
     helper 'forem/topics'
 
     def index

--- a/forem.gemspec
+++ b/forem.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '~> 3.1'
   s.add_dependency 'simple_form'
-  s.add_dependency 'cancan', '1.6.7'
+  s.add_dependency 'cancan', '1.6.8'
   s.add_dependency 'forem-redcarpet', '1.0.0'
   s.add_dependency 'workflow', '0.8.0'
   s.add_dependency 'friendly_id', '~> 4.0'


### PR DESCRIPTION
Hi,

we needed to update CanCan to 1.6.8, due to a dependency of the app in which we're integrating forem in, so we implemented and tested the solution proposed in issue #253. Tests pass on Rails 3.2.9.

It is OK for you to merge?

Thanks,

~Marcello, cc: @lleirborras 
