### PR TITLE
Remove gemoji and replace it with emoticon_fontify gem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Here's a comprehensive list of the features currently in Forem:
 * Text Formatting
   * Posts are HTML escaped and pre tagged by default.
   * [Pluggable formatters for other behaviour (Markdown, Textile)](https://github.com/radar/forem/wiki/Formatters)
-  * :point_right: :tada: [:emoji:](http://www.emoji-cheat-sheet.com/) :tada: :point_left:
 * [Theme support](https://github.com/radar/forem/wiki/Theming)
 * [A flexible permissions system](https://github.com/radar/forem/wiki/Authorization-System)
 * [Translations](https://github.com/radar/forem/wiki/Translations)

--- a/app/helpers/forem/application_helper.rb
+++ b/app/helpers/forem/application_helper.rb
@@ -1,6 +1,9 @@
+require 'emoticon_fontify'
+
 module Forem
   module ApplicationHelper
     include FormattingHelper
+
     # processes text with installed markup formatter
     def forem_format(text, *options)
       forem_emojify(as_formatted_html(text))
@@ -34,20 +37,14 @@ module Forem
       end
     end
 
-    def forem_atom_auto_discovery_link_tag  
+    def forem_atom_auto_discovery_link_tag
       if controller_name == "topics" && action_name == "show"
         auto_discovery_link_tag(:atom)
       end
     end
 
     def forem_emojify(content)
-      h(content).to_str.gsub(/:([a-z0-9\+\-_]+):/) do |match|
-        if Emoji.names.include?($1)
-          '<img alt="' + $1 + '" height="20" src="' + asset_path("emoji/#{$1}.png") + '" style="vertical-align:middle" width="20" />'
-        else
-          match
-        end
-      end.html_safe if content.present?
+      ::EmoticonFontify.emoticon_fontify(h(content))
     end
   end
 end

--- a/forem.gemspec
+++ b/forem.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'forem-redcarpet', '1.0.0'
   s.add_dependency 'workflow', '0.8.0'
   s.add_dependency 'friendly_id', '~> 4.0'
-  s.add_dependency 'gemoji', '= 1.1.2'
+  s.add_dependency 'emoticon_fontify'
 end

--- a/lib/forem/engine.rb
+++ b/lib/forem/engine.rb
@@ -31,7 +31,6 @@ module ::Forem
 end
 
 require 'simple_form'
-require 'emoji/railtie'
 
 # We need one of the two pagination engines loaded by this point.
 # We don't care which one, just one of them will do.


### PR DESCRIPTION
## Removal of gemoji
- Apple almost certainly doesn't freely licence their Emoji font so
  using it without permission is probably legally a Bad Idea™.
- The Gemoji gem has issues disabled so if there's ever a problem
  asking questions or getting it fixed is near impossible.
- Gemoji recomends serving the images from /public which won't work in
  a mounted engine.
- Serving the Gemoji images from /assets is possible but slows down
  precompilation hugely (over 800 images!)
- Do we really need over 800 emoji and is it worth the 4MB penalty?
## Addition of emoticon_fontify
- The emoticon font is properly licenced, free and open source.
- Hundreds less emojis to remember / bloat an app's size.
- Instead of hard to remember codes like `:stuck_out_tongue_closed_eyes:`
  you can simply type an emoticon as you normally would and it is
  converted :-)
- Helper method is built into the gem.
- The gem is an engine so the necessary font and stylesheet assets are
  automatically included in the asset pipeline (just need requiring the usual way).
- As it's a font the emoticons can easily be styled to match the
  forum's text color and size, it will zoom well, and display crisply on
  double pixel ratio devices.
## Making it work

I have modified Forem to use the gem. A user of forum only has to do a few simple things to get it working.

First one must require the gem so that the asset pipeline can do its thing.

``` ruby
require 'emoticon_fontify'
```

Finally (yep just 2 steps) one has to add the emoticon stylesheet to their `application.css`

``` css
 *= require "emoticon_fontify/emoticons"
```

I'd love to hear any thoughts or suggestions. And feel free to submit an issue on the [emoticon_fontify](https://github.com/sfcgeorge/emoticon_fontify) page if you find anything broken and I'll look into it.
