### PR TITLE
Problem with Subscription#send_notification when user is removed

### DIFF
--- a/app/models/forem/subscription.rb
+++ b/app/models/forem/subscription.rb
@@ -8,7 +8,9 @@ module Forem
     attr_accessible :subscriber_id
 
     def send_notification(post_id)
-      SubscriptionMailer.topic_reply(post_id, subscriber.id).deliver
+      # If a user cannot be found, then no-op
+      # This will happen if the user record has been deleted.
+      SubscriptionMailer.topic_reply(post_id, subscriber.id).deliver if subscriber
     end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -20,5 +20,12 @@ describe Forem::Subscription do
       topic.subscriptions.should_receive(:create!).with(:subscriber_id => topic.user_id)
       topic.run_callbacks(:create)
     end
+
+    # Regression test for #375
+    it "does not send a notification when user is missing" do
+      subscription = Forem::Subscription.new
+      Forem::SubscriptionMailer.should_not_receive(:topic_reply)
+      subscription.send_notification(1)
+    end
   end
 end


### PR DESCRIPTION
If the user object associated via subscription_id on the Subscription model is removed the send_notification method throws exceptions as it tries to pull the .id off a nil object.
