### PR TITLE
Remove a negation in the italian translation

### DIFF
--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -82,7 +82,7 @@ it:
     post:
       buttons:
         reply: Invia la risposta
-      created: La tua risposta non è stata inviata.
+      created: La tua risposta è stata inviata.
       new: Risposta
       not_created: La tua risposta non può essere inviata.
       not_created_topic_locked: Non puoi rispondere ad un argomento bloccato.


### PR DESCRIPTION
The old translation was saying "Your reply has not been posted."

I also just noticed there are some inconsistencies in the italian translation, I will look into it. Does `en.yml` contain all the strings in Forem right?
