### PR TITLE
Refine i18n

### DIFF
--- a/app/views/forem/admin/categories/edit.html.erb
+++ b/app/views/forem/admin/categories/edit.html.erb
@@ -1,3 +1,3 @@
-<h2><%= t("forem.admin.category.edit", :title => @category.name, :default => "Editing the %{title} Forum Category") %></h2>
+<h2><%= t(".edit_category", :title => @category.name, :default => "Editing the %{title} Forum Category") %></h2>
 
 <%= render "form" %>

--- a/app/views/forem/admin/categories/edit.html.erb
+++ b/app/views/forem/admin/categories/edit.html.erb
@@ -1,3 +1,3 @@
-<h2><%= t("forem.category.edit", :title => @category.name) %></h2>
+<h2><%= t("forem.admin.category.edit", :title => @category.name, :default => "Editing the %{title} Forum Category") %></h2>
 
 <%= render "form" %>

--- a/app/views/forem/admin/categories/index.html.erb
+++ b/app/views/forem/admin/categories/index.html.erb
@@ -5,17 +5,17 @@
 <table id='forums' class='forums subdued' cellspacing='0'>
   <thead>
     <tr>
-      <th><%= t('edit', :scope => 'forem.admin.categories') %></th>
-      <th><%= t('delete', :scope => 'forem.admin.categories') %></th>
-      <th><%= t('category', :scope => 'forem.admin.categories') %></th>
+      <th><%= t('.edit') %></th>
+      <th><%= t('.delete') %></th>
+      <th><%= t('.category') %></th>
 
     </tr>
   </thead>
   <tbody>
     <% @category.each do |category| %>
       <tr class="forum <%= cycle("odd", "even") %>">
-        <td><%= link_to t('edit', :scope => 'forem.admin.categories'), forem.edit_admin_category_path(category) %></td>
-        <td><%= link_to t('delete', :scope => 'forem.admin.categories'), forem.admin_category_path(category), :method => :delete, :confirm => t("delete_confirm", :scope => "forem.admin.categories") %></td>
+        <td><%= link_to t('.edit'), forem.edit_admin_category_path(category) %></td>
+        <td><%= link_to t('.delete'), forem.admin_category_path(category), :method => :delete, :confirm => t("delete_confirm", :scope => "forem.admin.categories") %></td>
         <td>
           <%= forem_emojify(category.name) %>
         </td>

--- a/app/views/forem/admin/categories/new.html.erb
+++ b/app/views/forem/admin/categories/new.html.erb
@@ -1,3 +1,3 @@
-<h2><%= t("forem.admin.category.new") %></h2>
+<h2><%= t(".create_category") %></h2>
 
 <%= render "form" %>

--- a/app/views/forem/admin/categories/new.html.erb
+++ b/app/views/forem/admin/categories/new.html.erb
@@ -1,3 +1,3 @@
-<h2><%= t("forem.category.new") %></h2>
+<h2><%= t("forem.admin.category.new") %></h2>
 
 <%= render "form" %>

--- a/app/views/forem/admin/forums/edit.html.erb
+++ b/app/views/forem/admin/forums/edit.html.erb
@@ -1,3 +1,3 @@
-<h2><%= t("forem.forum.edit", :title => forem_emojify(@forum.title)).html_safe %></h2>
+<h2><%= t(".edit_forum", :title => forem_emojify(@forum.title)).html_safe %></h2>
 
 <%= render "form" %>

--- a/app/views/forem/admin/forums/index.html.erb
+++ b/app/views/forem/admin/forums/index.html.erb
@@ -8,8 +8,8 @@
   <table id='forums' class='forums subdued' cellspacing='0'>
     <thead>
       <tr>
-        <th><%= t('edit', :scope => 'forem.admin.forums') %></th>
-        <th><%= t('delete', :scope => 'forem.admin.forums') %></th>
+        <th><%= t('.edit') %></th>
+        <th><%= t('.delete') %></th>
         <th><%= t('forum', :scope => 'forem.general') %></th>
         <th><%= t('topics', :scope => 'forem.general') %></th>
         <th><%= t('posts', :scope => 'forem.general') %></th>
@@ -18,8 +18,8 @@
     <tbody>
       <% forums.each do |forum| %>
         <tr class="forum <%= cycle("odd", "even") %>">
-          <td><%= link_to t('edit', :scope => 'forem.admin.forums'), forem.edit_admin_forum_path(forum) %></td>
-          <td><%= link_to t('delete', :scope => 'forem.admin.forums'), forem.admin_forum_path(forum), :method => :delete, :confirm => t("delete_confirm", :scope => "forem.admin.forums") %></td>
+          <td><%= link_to t('.edit'), forem.edit_admin_forum_path(forum) %></td>
+          <td><%= link_to t('.delete'), forem.admin_forum_path(forum), :method => :delete, :confirm => t("delete_confirm", :scope => "forem.admin.forums") %></td>
           <td>
             <%= link_to forem_emojify(forum.title), forem.forum_path(forum) %>
             <div class='description'><%= forem_format(forum.description) %></div>

--- a/app/views/forem/admin/forums/index.html.erb
+++ b/app/views/forem/admin/forums/index.html.erb
@@ -37,7 +37,7 @@
                   <%= link_to moderator, [forem, :admin, moderator] %>
                 <% end.to_sentence %>
               <% else %>
-                None
+                <%= t('.none') %>
               <% end %>
             </span>
           </td>

--- a/app/views/forem/admin/forums/new.html.erb
+++ b/app/views/forem/admin/forums/new.html.erb
@@ -1,3 +1,3 @@
-<h2><%= t("forem.forum.new") %></h2>
+<h2><%= t(".create_forum") %></h2>
 
 <%= render "form" %>

--- a/app/views/forem/admin/groups/index.html.erb
+++ b/app/views/forem/admin/groups/index.html.erb
@@ -12,8 +12,8 @@
   <tbody>
     <% @groups.each do |group| %>
       <tr>
-        <td><%= link_to t('edit'), forem.admin_group_path(group) %></td>
-        <td><%= link_to t('delete'), forem.admin_group_path(group), :method => :delete %></td>
+        <td><%= link_to t('edit', :scope => 'forem.admin.groups'), forem.admin_group_path(group) %></td>
+        <td><%= link_to t('delete', :scope => 'forem.admin.groups'), forem.admin_group_path(group), :method => :delete %></td>
         <td><%= link_to forem_emojify(group.name), forem.admin_group_path(group) %></td>
       </tr>
     <% end %>

--- a/app/views/forem/admin/groups/show.html.erb
+++ b/app/views/forem/admin/groups/show.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t('forem.admin.group.members', :group => forem_emojify(@group.name)) %></h2>
+<h2><%= t('.members', :group => forem_emojify(@group.name)) %></h2>
 
 <%= text_field_tag "new_member" %><%= button_tag t(".add_member"), :disabled => true, :id => "add_member", "data-group-id" => "#{@group.id}"  %>
 

--- a/app/views/forem/admin/topics/edit.html.erb
+++ b/app/views/forem/admin/topics/edit.html.erb
@@ -1,3 +1,3 @@
-<h2><%= t("forem.topic.edit", :subject => @topic.subject) %></h2>
+<h2><%= t(".edit_topic", :subject => @topic.subject) %></h2>
 
 <%= render "form" %>

--- a/app/views/forem/moderation/index.html.erb
+++ b/app/views/forem/moderation/index.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t('.title', :forum => forum) %></h2>
+<h2><%= t('forem.moderation.title', :forum => forum.title) %></h2>
 
 <h3><%= t('posts_count', :count => @posts.count, :scope => 'forem.general') %></h3>
 
@@ -9,5 +9,5 @@
       <%= render posts, :mass_moderation => true %>
     <% end %>
   </div>
-  <%= submit_tag "Moderate" %>
+  <%= submit_tag t('forem.posts.moderation.moderate') %>
 <% end %>

--- a/app/views/forem/topics/new.html.erb
+++ b/app/views/forem/topics/new.html.erb
@@ -1,5 +1,5 @@
 <%= render :partial => 'forem/forums/head', :locals => { :forum => @topic.forum } %>
 
-<h2><%= t("forem.topic.new") %></h2>
+<h2><%= t(".create_topic") %></h2>
 
 <%= render "form" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
       category:
         index: Manage Forum Categories
         new: Creating a new Forum Category
+        edit: "Editing the %{title} Forum Category"
         new_link: New Forum Category
         deleted: The selected forum category has been deleted.
         created: This forum category has been created.
@@ -167,6 +168,7 @@ en:
         pending_review: This post is currently pending review. Only the user who posted it and moderators can view it.
     moderation:
       title: "Moderation tools for %{forum}"
+    moderator_groups: Moderator Groups
   helpers:
     submit:
       forum:
@@ -177,9 +179,13 @@ en:
         update: Update Topic
   simple_form:
     labels:
+      category:
+        name: Name
       forum:
         title: Title
         description: Description
+        category: Category
+        moderators: Moderators
       topic:
         subject: Subject
         locked: Locked

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,7 +19,6 @@ en:
       welcome: "Welcome to forem's Admin Area."
       forum:
         index: Manage Forums
-        new: Creating a new forum
         new_link: New Forum
         deleted: The selected forum has been deleted.
         created: This forum has been created.
@@ -27,14 +26,18 @@ en:
         updated: That forum has been updated.
         not_updated: This forum could not be updated.
       forums:
-        edit: Edit
-        delete: Delete
         category: Category
         delete_confirm: Are you sure you want to delete this forum?
         index:
           last_post: Last post
           none: None
           moderators: Moderators
+          edit: Edit
+          delete: Delete
+        new:
+          create_forum: Creating a new forum
+        edit:
+          edit_forum: "Editing the %{title} forum"
       group:
         index: Manage Groups
         new: New Group
@@ -43,14 +46,13 @@ en:
         deleted: The selected group has been deleted.
       groups:
         show:
+          members: Members
           add_member: Add
         edit: Edit
         delete: Delete
         name: Name
       category:
         index: Manage Forum Categories
-        new: Creating a new Forum Category
-        edit: "Editing the %{title} Forum Category"
         new_link: New Forum Category
         deleted: The selected forum category has been deleted.
         created: This forum category has been created.
@@ -58,10 +60,18 @@ en:
         updated: That forum category has been updated.
         not_updated: This forum category could not be updated.
       categories:
-        edit: Edit
-        delete: Delete
-        category: Category
         delete_confirm: Are you sure you want to delete this forum category?
+        edit:
+          edit_category: "Editing the %{title} Forum Category"
+        new:
+          create_category: Creating a new Forum Category
+        index:
+          edit: Edit
+          delete: Delete
+          category: Category
+      topics:
+        edit:
+          edit_topic: Editing topic
     common:
       pages: Pages
     errors:
@@ -70,8 +80,6 @@ en:
     forum:
       header: "Viewing %{title}"
       forums: Forums
-      new: Creating a new forum
-      edit: "Editing the %{title} forum"
       topics_count:
         zero: 0 topics
         one: 1 topic
@@ -102,8 +110,6 @@ en:
       quote: Quote
       delete: Delete
       created: This topic has been created.
-      new: Creating a new topic
-      edit: Editing topic
       not_created: This topic could not be created.
       deleted: Your topic has been deleted.
       cannot_delete: You cannot delete a topic you do not own.
@@ -127,6 +133,8 @@ en:
         'true': This topic is now pinned.
         'false': This topic is now unpinned.
     topics:
+      new:
+        create_topic: Creating a new topic
       show:
         reply: Reply
         delete: Delete

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -16,10 +16,7 @@ fa:
       forums:
         edit: ویرایش
         delete: حذف
-        forum: انجمن
         category: دسته بندی
-        topics: موضوعات
-        posts: مطالب
         delete_confirm: آیا از حذف این انجمن مطمئن هستید؟
         index:
           last_post: آخرین مطلب
@@ -60,8 +57,6 @@ fa:
       index:
         title: انجمن ها
         forum: انجمن
-        topics: موضوعات
-        posts: مطالب
         views: نمایش ها
         last_post: 'آخرین مطلب:'
         none: هیچ کدام

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -117,7 +117,6 @@ pl:
         create: Utwórz temat
         update: Aktualizuj temat
   simple_form:
-    topic: Temat
     labels:
       forum:
         title: Tytuł

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -4,7 +4,6 @@ pt-BR:
       area: Área de Administração
       welcome: "Bem vindo"
       forum:
-        edit: "Editando o fórum %{title}"
         index: Gerenciar Fórum
         new: Novo Fórum
         new_link: Novo Fórum

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -44,9 +44,9 @@ ru:
       groups:
         show:
           add_member: Добавить
-          edit: Редактировать
-          delete: Удалить
-          name: Название
+        edit: Редактировать
+        delete: Удалить
+        name: Название
       category:
         index: Управление категориями
         new: Создание новой категории


### PR DESCRIPTION
Changes:
- Add missing translation lookup
- Add missing keys in en locale file
- Remove unused translation keys (which were added into en file in localeapp.com)

But there are some more problems not fix yet. eg. some translation scope are inconsistent or duplicated:
- `views/forem/admin/forums/new.html.erb` is using `t("forem.forum.new")`. but `views/forem/admin/groups/new.html.erb` is using `t("forem.admin.group.new")`.
- `forem.admin.forum.new` and `forem.forum.new` are duplicate. Only `forem.forum.new` is in use.

If there is a plan to fix it?
