### PR TITLE
Modified gem to allow page number rendering in reply_to links

### DIFF
--- a/app/controllers/forem/topics_controller.rb
+++ b/app/controllers/forem/topics_controller.rb
@@ -79,6 +79,12 @@ module Forem
         redirect_to @forum and return
       end
     end
+    
+    def post_count(topic)
+      a=topic.posts.flatten.collect{|p| p.id}.each_with_index.to_a
+      a=a.map{|a| {:id=>a[0], :position=>a[1]+1}}
+      return a
+    end
 
     def register_view
       @topic.register_view_by(forem_user)

--- a/app/controllers/forem/topics_controller.rb
+++ b/app/controllers/forem/topics_controller.rb
@@ -15,6 +15,13 @@ module Forem
         @posts = @posts.page(params[:page]).per(Forem.per_page)
       end
     end
+    
+    #Pulls ids and positions for topic posts for use in reply to links
+    def post_count(topic)
+      a=topic.posts.flatten.collect{|p| p.id}.each_with_index.to_a
+      a=a.map{|a| {:id=>a[0], :position=>a[1]+1}}
+      return a
+    end
 
     def new
       authorize! :create_topic, @forum
@@ -78,12 +85,6 @@ module Forem
         flash.alert = t("forem.topic.not_found")
         redirect_to @forum and return
       end
-    end
-    
-    def post_count(topic)
-      a=topic.posts.flatten.collect{|p| p.id}.each_with_index.to_a
-      a=a.map{|a| {:id=>a[0], :position=>a[1]+1}}
-      return a
     end
 
     def register_view

--- a/app/controllers/forem/topics_controller.rb
+++ b/app/controllers/forem/topics_controller.rb
@@ -13,14 +13,10 @@ module Forem
           @posts = @posts.approved_or_pending_review_for(forem_user)
         end
         @posts = @posts.page(params[:page]).per(Forem.per_page)
+        #Provides ids of posts and their positions
+        post_positions = @topic.posts.flatten.collect{|p| p.id}.each_with_index.to_a
+        @post_positions = post_positions.map{|a| {:id=>a[0], :position=>a[1]+1}}
       end
-    end
-    
-    #Pulls ids and positions for topic posts for use in reply to links
-    def post_count(topic)
-      a=topic.posts.flatten.collect{|p| p.id}.each_with_index.to_a
-      a=a.map{|a| {:id=>a[0], :position=>a[1]+1}}
-      return a
     end
 
     def new

--- a/app/views/forem/posts/_post.html.erb
+++ b/app/views/forem/posts/_post.html.erb
@@ -31,7 +31,9 @@
 
     <% if post.reply_to %>
       <span class='in_reply_to'>
-        <%= link_to "#{t("forem.post.in_reply_to")} #{post.reply_to.user}", "#post-#{post.reply_to.id}" %>
+        <% position = @post_positions.select{|p| p[:id].equal? post.reply_to.id}.first[:position] %>
+        <% page = Integer(Float(position-1)/Float(Forem.per_page)+1) %>
+        <%= link_to "#{t("forem.post.in_reply_to")} #{post.reply_to.user}", "?page=#{page}#post-#{post.reply_to.id}" %>
       </span>
     <% end %>
 

--- a/app/views/forem/topics/show.html.erb
+++ b/app/views/forem/topics/show.html.erb
@@ -37,7 +37,7 @@
   <%= forem_pages_widget(@posts) %>
 
   <div id='posts'>
-    <%= render :partial => "forem/posts/post", :collection => @posts %>
+    <%= render :partial => "forem/posts/post", :collection => @posts, :locals => {:post_positions=>@post_positions} %>
   </div>
 
   <%= forem_pages_widget(@posts) %>


### PR DESCRIPTION
Added @post_positions to topics show action:

``` ruby
def show
  if find_topic
    register_view
    @posts = @topic.posts
    unless forem_admin_or_moderator?(@forum)
      @posts = @posts.approved_or_pending_review_for(forem_user)
    end
    @posts = @posts.page(params[:page]).per(Forem.per_page)
    #Provides ids of posts and their positions
    post_positions = @topic.posts.flatten.collect{|p| p.id}.each_with_index.to_a
    @post_positions = post_positions.map{|a| {:id=>a[0], :position=>a[1]+1}}
  end
end
```

Modified posts/_post.html.erb view:

``` erb
<% if post.reply_to %>
  <span class='in_reply_to'>
    <% position = @post_positions.select{|p| p[:id].equal? post.reply_to.id}.first[:position] %>
    <% page = Integer(Float(position-1)/Float(Forem.per_page)+1) %>
    <%= link_to "#{t("forem.post.in_reply_to")} #{post.reply_to.user}", "?page=#{page}#post-#{post.reply_to.id}" %>
  </span>
<% end %>
```

Modified topics/show.html.erb to pass data to partial:

``` erb
<div id='posts'>
  <%= render :partial => "forem/posts/post", :collection => @posts, :locals => {:post_positions=>@post_positions} %>
</div>
```
