### PR TITLE
Add :dependent => :destroy to topic subscriptions and views

### DIFF
--- a/app/models/forem/concerns/viewable.rb
+++ b/app/models/forem/concerns/viewable.rb
@@ -6,7 +6,7 @@ module Forem
       extend ActiveSupport::Concern
 
       included do
-        has_many :views, :as => :viewable
+        has_many :views, :as => :viewable, :dependent => :destroy
       end
 
       def view_for(user)

--- a/app/models/forem/topic.rb
+++ b/app/models/forem/topic.rb
@@ -27,7 +27,7 @@ module Forem
 
     belongs_to :forum
     belongs_to :user, :class_name => Forem.user_class.to_s
-    has_many   :subscriptions
+    has_many   :subscriptions, :dependent => :destroy
     has_many   :posts, :dependent => :destroy, :order => "forem_posts.created_at ASC"
 
     accepts_nested_attributes_for :posts

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe Forem::Subscription do
+
+  it "is valid with valid attributes" do
+    FactoryGirl.build(:subscription).should be_valid
+  end
+
   describe "topic subscriptions" do
     before(:each) do
       Forem::Topic.any_instance.stub(:set_first_post_user)

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -20,6 +20,24 @@ describe Forem::Topic do
     end
   end
 
+  context "deletion" do
+    it "deletes views, subscriptions and posts" do
+      FactoryGirl.create(:post, :topic => @topic)
+      FactoryGirl.create(:subscription, :topic => @topic)
+      FactoryGirl.create(:topic_view, :viewable => @topic)
+
+      @topic.posts.count.should be > 0
+      @topic.subscriptions.count.should be > 0
+      @topic.views.count.should be > 0
+
+      @topic.destroy
+
+      Forem::Post.where('topic_id = ?', @topic.id).first.should be_nil
+      Forem::Subscription.where('topic_id = ?', @topic.id).first.should be_nil
+      Forem::View.where('viewable_id = ?', @topic.id).first.should be_nil
+    end
+  end
+
   describe "validations" do
     it "requires a subject" do
       @topic.subject = nil

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -32,9 +32,9 @@ describe Forem::Topic do
 
       @topic.destroy
 
-      Forem::Post.where('topic_id = ?', @topic.id).first.should be_nil
-      Forem::Subscription.where('topic_id = ?', @topic.id).first.should be_nil
-      Forem::View.where('viewable_id = ?', @topic.id).first.should be_nil
+      Forem::Post.exists?(:topic_id => @topic.id).should be_false
+      Forem::Subscription.exists?(:topic_id => @topic.id).should be_false
+      Forem::View.exists?(:viewable_id => @topic.id).should be_false
     end
   end
 

--- a/spec/models/view_spec.rb
+++ b/spec/models/view_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Forem::View do
+  let!(:view) { FactoryGirl.create(:topic_view) }
+
+  it "is valid with valid attributes" do
+    view.should be_valid
+  end
+
+  describe "validations" do
+    it "requires a viewable type" do
+      view.viewable_type = nil
+      view.should_not be_valid
+    end
+
+    it "requires a viewable" do
+      view.viewable = nil
+      view.should_not be_valid
+    end
+  end
+
+end

--- a/spec/support/factories/subscriptions.rb
+++ b/spec/support/factories/subscriptions.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :subscription, :class => Forem::Subscription do |f|
+    association :subscriber, :factory => :user
+    association :topic
+  end
+end

--- a/spec/support/factories/views.rb
+++ b/spec/support/factories/views.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :topic_view, :class => Forem::View do |f|
+    association :user
+    association :viewable, :factory => :topic
+  end
+end


### PR DESCRIPTION
If you use foreign key constraints in your database then it is not possible to delete a topic, since rows in other tables depend on the topic. 

This commit adds :dependent => :destroy to topic subscriptions and views which makes it possible.
