### PR TITLE
Moderation queue

### DIFF
--- a/app/controllers/forem/posts_controller.rb
+++ b/app/controllers/forem/posts_controller.rb
@@ -21,6 +21,7 @@ module Forem
       @post.user = forem_user
 
       if @post.save
+        ModerationQueueMailer.new_post(@post).deliver if @post.topic.user.forem_moderate_posts?
         create_successful
       else
         create_failed

--- a/app/controllers/forem/posts_controller.rb
+++ b/app/controllers/forem/posts_controller.rb
@@ -54,9 +54,17 @@ module Forem
     end
 
     def create_successful
-      Forem::ModerationQueueMailer.new_post(@post).deliver if forem_user.forem_moderate_posts?
+      deliver_moderation_notification if deliver_moderation_notifications_for_user?(forem_user)
       flash[:notice] = t("forem.post.created")
       redirect_to forum_topic_url(@topic.forum, @topic, :page => @topic.last_page)
+    end
+
+    def deliver_moderation_notification
+      ModerationQueueMailer.new_post(@post).deliver
+    end
+
+    def deliver_moderation_notifications_for_user?(user)
+      user.forem_moderate_posts?
     end
 
     def create_failed

--- a/app/controllers/forem/posts_controller.rb
+++ b/app/controllers/forem/posts_controller.rb
@@ -21,7 +21,6 @@ module Forem
       @post.user = forem_user
 
       if @post.save
-        Forem::ModerationQueueMailer.new_post(@post).deliver if forem_user.forem_moderate_posts?
         create_successful
       else
         create_failed
@@ -55,6 +54,7 @@ module Forem
     end
 
     def create_successful
+      Forem::ModerationQueueMailer.new_post(@post).deliver if forem_user.forem_moderate_posts?
       flash[:notice] = t("forem.post.created")
       redirect_to forum_topic_url(@topic.forum, @topic, :page => @topic.last_page)
     end

--- a/app/controllers/forem/posts_controller.rb
+++ b/app/controllers/forem/posts_controller.rb
@@ -21,7 +21,7 @@ module Forem
       @post.user = forem_user
 
       if @post.save
-        ModerationQueueMailer.new_post(@post).deliver if @post.topic.user.forem_moderate_posts?
+        Forem::ModerationQueueMailer.new_post(@post).deliver if forem_user.forem_moderate_posts?
         create_successful
       else
         create_failed

--- a/app/controllers/forem/topics_controller.rb
+++ b/app/controllers/forem/topics_controller.rb
@@ -23,7 +23,6 @@ module Forem
       @topic = @forum.topics.build(params[:topic], :as => :default)
       @topic.user = forem_user
       if @topic.save
-        ModerationQueueMailer.new_topic(@topic).deliver if @topic.user.forem_moderate_posts?
         create_successful
       else
         create_unsuccessful
@@ -56,12 +55,21 @@ module Forem
 
     protected
     def create_successful
+      deliver_moderation_notification if deliver_moderation_notifications_for_user?(forem_user)
       redirect_to [@forum, @topic], :notice => t("forem.topic.created")
     end
 
     def create_unsuccessful
       flash.now.alert = t('forem.topic.not_created')
       render :action => 'new'
+    end
+
+    def deliver_moderation_notification
+      ModerationQueueMailer.new_topic(@topic).deliver
+    end
+
+    def deliver_moderation_notifications_for_user?(user)
+      user.forem_moderate_posts?
     end
 
     def destroy_successful

--- a/app/controllers/forem/topics_controller.rb
+++ b/app/controllers/forem/topics_controller.rb
@@ -23,6 +23,7 @@ module Forem
       @topic = @forum.topics.build(params[:topic], :as => :default)
       @topic.user = forem_user
       if @topic.save
+        ModerationQueueMailer.new_topic(@topic).deliver if @topic.user.forem_moderate_posts?
         create_successful
       else
         create_unsuccessful

--- a/app/mailers/forem/moderation_queue_mailer.rb
+++ b/app/mailers/forem/moderation_queue_mailer.rb
@@ -4,16 +4,18 @@ module Forem
 
     def new_topic(topic)
       @topic = topic
-      
-      @admin_users = Forem.user_class.find_all_by_forem_admin(true)
-      mail(:to => @admin_users.map(&:email), :subject => I18n.t('forem.topic.moderation_needed'))
+      mail(:to => admin_users.map(&:email), :subject => I18n.t('forem.topic.moderation_needed'))
     end
 
     def new_post(post)
       @post = post
-      
-      @admin_users = Forem.user_class.find_all_by_forem_admin(true)
-      mail(:to => @admin_users.map(&:email), :subject => I18n.t('forem.post.moderation_needed'))
+      mail(:to => admin_users.map(&:email), :subject => I18n.t('forem.post.moderation_needed'))
+    end
+
+    private
+
+    def admin_users
+      Forem.user_class.find_all_by_forem_admin(true)
     end
   end
 end

--- a/app/mailers/forem/moderation_queue_mailer.rb
+++ b/app/mailers/forem/moderation_queue_mailer.rb
@@ -1,0 +1,20 @@
+module Forem
+  class ModerationQueueMailer < ActionMailer::Base
+    default :from => Forem.email_from_address
+
+    def new_topic(topic)
+      @topic = topic
+      
+      @admin_users = Forem.user_class.find_all_by_forem_admin(true)
+      mail(:to => @admin_users.map(&:email), :subject => I18n.t('forem.topic.moderation_needed'))
+    end
+
+    def new_post(post)
+      @post = post
+      
+      @admin_users = Forem.user_class.find_all_by_forem_admin(true)
+      mail(:to => @admin_users.map(&:email), :subject => I18n.t('forem.post.moderation_needed'))
+    end
+  end
+end
+

--- a/app/models/forem/post.rb
+++ b/app/models/forem/post.rb
@@ -38,6 +38,7 @@ module Forem
     after_save :approve_user,   :if => :approved?
     after_save :blacklist_user, :if => :spam?
     after_save :email_topic_subscribers, :if => Proc.new { |p| p.approved? && !p.notified? }
+    after_save :send_moderation_notification, :if => Proc.new { |p| p.topic.user.forem_moderate_posts? }
 
     class << self
       def approved
@@ -97,6 +98,10 @@ module Forem
       if topic && user
         topic.subscribe_user(user.id)
       end
+    end
+
+    def send_moderation_notification
+      ModerationQueueMailer.new_post(self).deliver if topic.user.forem_moderate_posts?
     end
 
     def email_topic_subscribers

--- a/app/models/forem/post.rb
+++ b/app/models/forem/post.rb
@@ -38,7 +38,6 @@ module Forem
     after_save :approve_user,   :if => :approved?
     after_save :blacklist_user, :if => :spam?
     after_save :email_topic_subscribers, :if => Proc.new { |p| p.approved? && !p.notified? }
-    after_save :send_moderation_notification, :if => Proc.new { |p| p.topic.user.forem_moderate_posts? }
 
     class << self
       def approved
@@ -98,10 +97,6 @@ module Forem
       if topic && user
         topic.subscribe_user(user.id)
       end
-    end
-
-    def send_moderation_notification
-      ModerationQueueMailer.new_post(self).deliver if topic.user.forem_moderate_posts?
     end
 
     def email_topic_subscribers

--- a/app/views/forem/moderation_queue_mailer/new_post.text.erb
+++ b/app/views/forem/moderation_queue_mailer/new_post.text.erb
@@ -1,3 +1,3 @@
-<%= I18n.t('moderation_needed', :scope => 'forem.post') %> <%= I18n,t('moderation_view_here', :scope => 'forem.post') %>
+<%= I18n.t('moderation_needed', :scope => 'forem.post') %> <%= I18n.t('moderation_view_here', :scope => 'forem.post') %>
 
 <%= forem.forum_topic_url(@post.topic.forum_id, @post.topic) %>

--- a/app/views/forem/moderation_queue_mailer/new_post.text.erb
+++ b/app/views/forem/moderation_queue_mailer/new_post.text.erb
@@ -1,0 +1,3 @@
+<%= I18n.t('moderation_needed', :scope => 'forem.post') %> You can view it here:
+
+<%= forem.forum_topic_url(@post.topic.forum_id, @post.topic) %>

--- a/app/views/forem/moderation_queue_mailer/new_post.text.erb
+++ b/app/views/forem/moderation_queue_mailer/new_post.text.erb
@@ -1,3 +1,3 @@
-<%= I18n.t('moderation_needed', :scope => 'forem.post') %> You can view it here:
+<%= I18n.t('moderation_needed', :scope => 'forem.post') %> <%= I18n,t('moderation_view_here', :scope => 'forem.post') %>
 
 <%= forem.forum_topic_url(@post.topic.forum_id, @post.topic) %>

--- a/app/views/forem/moderation_queue_mailer/new_topic.text.erb
+++ b/app/views/forem/moderation_queue_mailer/new_topic.text.erb
@@ -1,0 +1,3 @@
+<%= I18n.t('moderation_needed', :scope => 'forem.topic') %> You can view it here:
+
+<%= forem.forum_topic_url(@topic.forum_id, @topic) %>

--- a/app/views/forem/moderation_queue_mailer/new_topic.text.erb
+++ b/app/views/forem/moderation_queue_mailer/new_topic.text.erb
@@ -1,3 +1,3 @@
-<%= I18n.t('moderation_needed', :scope => 'forem.topic') %> You can view it here:
+<%= I18n.t('moderation_needed', :scope => 'forem.topic') %> <%= I18n,t('moderation_view_here', :scope => 'forem.topic') %>
 
 <%= forem.forum_topic_url(@topic.forum_id, @topic) %>

--- a/app/views/forem/moderation_queue_mailer/new_topic.text.erb
+++ b/app/views/forem/moderation_queue_mailer/new_topic.text.erb
@@ -1,3 +1,3 @@
-<%= I18n.t('moderation_needed', :scope => 'forem.topic') %> <%= I18n,t('moderation_view_here', :scope => 'forem.topic') %>
+<%= I18n.t('moderation_needed', :scope => 'forem.topic') %> <%= I18n.t('moderation_view_here', :scope => 'forem.topic') %>
 
 <%= forem.forum_topic_url(@topic.forum_id, @topic) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,7 @@ en:
         no_option_selected: No moderation option was selected.
       received_reply: A topic you have subscribed to has received a reply.
       moderation_needed: New topic needs moderation.
+      moderation_view_here: "You can view it here:"
       reply: Reply
       quote: Quote
       delete: Delete
@@ -153,6 +154,7 @@ en:
       not_created: Your reply could not be posted.
       not_created_topic_locked: You cannot reply to a locked topic.
       moderation_needed: New post needs moderation.
+      moderation_view_here: "You can view it here:"
       edited: Your post has been edited.
       not_edited: Your post could not be edited.
       deleted: Your post has been deleted.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,7 @@ en:
         success: The selected topic has been moderated.
         no_option_selected: No moderation option was selected.
       received_reply: A topic you have subscribed to has received a reply.
+      moderation_needed: New topic needs moderation.
       reply: Reply
       quote: Quote
       delete: Delete
@@ -151,6 +152,7 @@ en:
       edit: Edit
       not_created: Your reply could not be posted.
       not_created_topic_locked: You cannot reply to a locked topic.
+      moderation_needed: New post needs moderation.
       edited: Your post has been edited.
       not_edited: Your post could not be edited.
       deleted: Your post has been deleted.

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1,16 +1,42 @@
 require 'spec_helper'
 
 describe Forem::PostsController do
+  let!(:forum) { create(:forum) }
+  let!(:user)  { create(:user) }
+  let!(:topic) { create(:approved_topic, :forum => forum, :user => user) }
+
   context "not signed in" do
-    let(:forum) { create(:forum) }
-    let(:user)  { create(:user) }
-    let(:topic) { create(:approved_topic, :forum => forum, :user => user) }
     let(:first_post) { topic.posts.first }
 
     it "cannot delete posts" do
       delete :destroy, :topic_id => topic.to_param, :id => first_post.to_param
       response.should redirect_to('/users/sign_in')
       flash.alert.should == "You must sign in first."
+    end
+  end
+
+  context "signed in" do
+    context "as an unapproved user" do
+      before do
+        user.update_column(:forem_state, "pending_review")
+        controller.stub :forem_user => user
+      end
+
+      it "sends moderation emails" do
+        Forem::ModerationQueueMailer.should_receive(:new_post).and_return(double('Mailer', :deliver => nil))
+        post :create, :post => { :text => "This is a brand new post."}, :topic_id => topic.id
+      end
+    end
+
+    context "as an approved user" do
+      before do
+        controller.stub :forem_user => user
+      end
+
+      it "does not send moderation emails" do
+        Forem::ModerationQueueMailer.should_not_receive(:new_post)
+        post :create, :post => { :text => "This is a brand new post."}, :topic_id => topic.id
+      end
     end
   end
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -23,7 +23,7 @@ describe Forem::PostsController do
       end
 
       it "sends moderation emails" do
-        Forem::ModerationQueueMailer.should_receive(:new_post).and_return(double('Mailer', :deliver => nil))
+        controller.should_receive(:deliver_moderation_notification)
         post :create, :post => { :text => "This is a brand new post."}, :topic_id => topic.id
       end
     end
@@ -34,7 +34,7 @@ describe Forem::PostsController do
       end
 
       it "does not send moderation emails" do
-        Forem::ModerationQueueMailer.should_not_receive(:new_post)
+        controller.should_not_receive(:deliver_moderation_notification)
         post :create, :post => { :text => "This is a brand new post."}, :topic_id => topic.id
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,7 +9,7 @@ FactoryGirl.define do
     factory :admin do |f|
       f.forem_admin true
     end
-    
+
     factory :not_autosubscribed do |f|
       f.forem_auto_subscribe false
     end

--- a/spec/features/moderation/new_users_spec.rb
+++ b/spec/features/moderation/new_users_spec.rb
@@ -11,6 +11,7 @@ describe "moderation" do
       end
 
       it "has their first topic moderated" do
+        Forem::ModerationQueueMailer.should_receive(:new_topic).and_return(double('Mailer', :deliver => nil))
         visit new_forum_topic_path(forum)
         fill_in "Subject", :with => "FIRST TOPIC"
         fill_in "Text", :with => "User's first words"
@@ -22,6 +23,7 @@ describe "moderation" do
 
 
       it "has their first post moderated" do
+        Forem::ModerationQueueMailer.should_receive(:new_post).and_return(double('Mailer', :deliver => nil))
         topic = FactoryGirl.create(:topic, :forum => forum)
         topic.approve!
         visit forum_topic_path(forum, topic)

--- a/spec/features/topics_spec.rb
+++ b/spec/features/topics_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "topics" do
 
   let(:forum) { FactoryGirl.create(:forum) }
-  let(:user) { FactoryGirl.create(:user, :login => 'other_forem_user', :email => "bob@boblaw.com", :custom_avatar_url => 'avatar.png') }
+  let(:user) { FactoryGirl.create(:user, :login => 'other_forem_user', :email => "bob@boblaw.com", :custom_avatar_url => 'avatar.png', :forem_state => 'approved') }
   let(:topic) { FactoryGirl.create(:approved_topic, :forum => forum, :user => user) }
   let(:other_user) { FactoryGirl.create(:user, :login => 'other_forem_user') }
   let(:other_topic) { FactoryGirl.create(:approved_topic, :subject => 'Another forem topic', :user => other_user, :forum => forum) }
@@ -31,7 +31,6 @@ describe "topics" do
         assert_seen("FIRST TOPIC", :within => :topic_header)
         assert_seen("omgomgomgomg", :within => :post_text)
         assert_seen("forem_user", :within => :post_user)
-
       end
 
       it "is invalid without subject but with post text" do


### PR DESCRIPTION
This is the work from #433, moved to the main repository since the [original owner gave up](https://github.com/radar/forem/pull/433#issuecomment-18812715).

---
- [x] Write tests for TopicsController moderation queue mailers
- [ ] Write tests for the mailer itself.
- [ ] Ensure users who are within a forum's `moderators` group get emailed.
- [ ] Include post text within moderation email, unlike Google Groups.
