### PR TITLE
Add configurable Forem#base_path

### DIFF
--- a/app/assets/javascripts/forem.js.erb
+++ b/app/assets/javascripts/forem.js.erb
@@ -1,7 +1,7 @@
 var Forem = {};
 
 <%
-  path = Rails.application.routes.named_routes[:forem].path
+  path = Forem.base_path
   # Rails 3.2 returns a Journey::Path::Pattern object, Rails 3.1 an actual path.
   path = path.spec.to_s if path.respond_to?(:spec)
   # Strips leading slashes from base_path

--- a/lib/forem.rb
+++ b/lib/forem.rb
@@ -11,12 +11,17 @@ require 'decorators'
 require 'localeapp'
 
 module Forem
-  mattr_accessor :user_class, :theme, :formatter, :default_gravatar, :default_gravatar_image,
+  mattr_accessor :base_path, :user_class, :theme, :formatter,
+                 :default_gravatar, :default_gravatar_image, :avatar_user_method,
                  :user_profile_links, :email_from_address, :autocomplete_field,
-                 :avatar_user_method, :per_page, :sign_in_path, :moderate_first_post
+                 :per_page, :sign_in_path, :moderate_first_post
 
 
   class << self
+    def base_path
+      @@base_path ||= Rails.application.routes.named_routes[:forem].path
+    end
+
     def moderate_first_post
       # Default it to true
       @@moderate_first_post == false ? false : true


### PR DESCRIPTION
For example, in the case where I mount under my engine instead of the main application
the previous code wasn't working and I had to use:

``` ruby
Forem.base_path = MyExtension::Engine.routes.named_routes[:forem].path
```

(which is now possible)
