### PR TITLE
check forum read permissions when user replies to topic/post

### DIFF
--- a/app/models/forem/ability.rb
+++ b/app/models/forem/ability.rb
@@ -41,7 +41,7 @@ module Forem
       end
 
       can :reply, Forem::Topic do |topic|
-        user.can_reply_to_forem_topic?(topic)
+        can?(:read, topic.forum) && user.can_reply_to_forem_topic?(topic)
       end
 
       can :edit_post, Forem::Forum do |forum|


### PR DESCRIPTION
fix for #445

i usually try to stay away from `any_instance` but here it was the most succinct way i could do it. if there's a better way to do this i'm all ears.

test was written at the controller level since it's about trying to bypass permissions by making a clever http POST. a feature test didn't make sense since presumably the user would not have access to links for replying to a post.
