### PR TITLE
bootstrap-sass isn't needed by default

### DIFF
--- a/forem.gemspec
+++ b/forem.gemspec
@@ -28,6 +28,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'gemoji', '= 1.1.2'
   s.add_dependency 'decorators', '~> 1.0.2'
   s.add_dependency 'localeapp'
-  s.add_dependency 'bootstrap-sass', '2.3.2.1'
   s.add_dependency 'select2-rails', '3.4.3'
 end


### PR DESCRIPTION
bootstrap-sass isn't needed by default. It should be took care by theme such as forem-bootstrap.
So this change will remove dependency to bootstrap-sass.
