### PR TITLE
Removed dependency on bootstrap-sass

### DIFF
--- a/forem.gemspec
+++ b/forem.gemspec
@@ -28,6 +28,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'gemoji', '= 1.1.2'
   s.add_dependency 'decorators', '~> 1.0.2'
   s.add_dependency 'localeapp'
-  s.add_dependency 'bootstrap-sass', '2.3.2.1'
   s.add_dependency 'select2-rails', '3.4.3'
 end


### PR DESCRIPTION
The dependency in the `forem.gemspec` file was preventing me from pulling the `3` branch of bootstrap-sass - I noticed it was already removed in `master` (in [this commit](https://github.com/radar/forem/commit/41095c8d1a816d272e440e9e47f3c5530e32252c)), so this PR is meant to match this.
