### PR TITLE
fix some links to forums page for consistency

### DIFF
--- a/app/views/forem/categories/show.html.erb
+++ b/app/views/forem/categories/show.html.erb
@@ -1,4 +1,4 @@
 <div class='category'>
-  <h2><%= link_to t('forem.forum.forums'), forem.forums_path %> &raquo; <%= link_to forem_emojify(@category), [forem, @category] %></h2>
+  <h2><%= link_to t('forem.forum.forums'), forem.root_path %> &raquo; <%= link_to forem_emojify(@category), [forem, @category] %></h2>
   <%= render @category %>
 </div>

--- a/app/views/forem/topics/_head.html.erb
+++ b/app/views/forem/topics/_head.html.erb
@@ -1,1 +1,1 @@
-<h2><%= link_to t('forem.forum.forums'), forem.forums_path %> &raquo; <%= link_to forem_emojify(topic.forum.title), [forem, topic.forum] %> &raquo; <%= forem_emojify(topic.subject) %></h2>
+<h2><%= link_to t('forem.forum.forums'), forem.root_path %> &raquo; <%= link_to forem_emojify(topic.forum.title), [forem, topic.forum] %> &raquo; <%= forem_emojify(topic.subject) %></h2>


### PR DESCRIPTION
For consistency, It would be better that you use forem.root_path (/) instead of forem.forums_path (/forums/).
