### PR TITLE
FriendlyId 5 compatible finders -- restore FriendlyId 4-style finders by...

### DIFF
--- a/app/models/forem/category.rb
+++ b/app/models/forem/category.rb
@@ -3,7 +3,7 @@ require 'friendly_id'
 module Forem
   class Category < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => :slugged
+    friendly_id :name, :use => [:slugged, :finders]
 
     has_many :forums
     validates :name, :presence => true

--- a/app/models/forem/forum.rb
+++ b/app/models/forem/forum.rb
@@ -5,7 +5,7 @@ module Forem
     include Forem::Concerns::Viewable
 
     extend FriendlyId
-    friendly_id :name, :use => :slugged
+    friendly_id :name, :use => [:slugged, :finders]
 
     belongs_to :category
 

--- a/app/models/forem/topic.rb
+++ b/app/models/forem/topic.rb
@@ -20,7 +20,7 @@ module Forem
     attr_accessor :moderation_option
 
     extend FriendlyId
-    friendly_id :subject, :use => :slugged
+    friendly_id :subject, :use => [:slugged, :finders]
 
     belongs_to :forum
     belongs_to :user, :class_name => Forem.user_class.to_s


### PR DESCRIPTION
... using the :finders addon

From the FiendlyId 5 docs (rails 4) --

> Finders are no longer overridden by default. If you want to do friendly finds, you must do Model.friendly.find rather than Model.find. You can however restore FriendlyId 4-style finders by using the :finders addon:
> 
>   friendly_id :foo, use: :slugged # you must do MyClass.friendly.find('bar')
>   # or...
>   friendly_id :foo, use: [:slugged, :finders] # you can now do MyClass.find('bar')

This commit enables the :finders addon, fixing problems with finder errors (https://github.com/radar/forem/issues/470), e.g.:

```
ActiveRecord::RecordNotFound in Forem::ForumsController#show
Couldn't find Forem::Forum with id=default
```
