### PR TITLE
Identify hidden topics in administrator's view

### DIFF
--- a/app/views/forem/topics/_topic.html.erb
+++ b/app/views/forem/topics/_topic.html.erb
@@ -6,6 +6,9 @@
     <% if topic.pinned? %>
       <span class='pin icon'></span>
     <% end %>
+    <% if topic.hidden? %>
+      <span class='hidden icon'></span>
+    <% end %>
     <% if forem_user && view = topic.view_for(forem_user) %>
       <% if topic.posts.exists?(["created_at > ?", view.updated_at]) %>
         <span class='new_posts icon'>new</span>

--- a/spec/features/admin/topics_spec.rb
+++ b/spec/features/admin/topics_spec.rb
@@ -13,9 +13,17 @@ describe "topics" do
   end
 
   it "can hide a topic" do
+    # make sure no hidden topics yet
+    visit forum_path(forum)
+    page.should_not have_selector("span.hidden.icon")
+
     visit forum_topic_path(forum, topic)
     click_link "Hide"
     flash_notice!("This topic is now hidden.")
+
+    # check for hidden topics
+    visit forum_path(forum)
+    page.should have_selector("span.hidden.icon")
 
     sign_out
 


### PR DESCRIPTION
It's helpful for administrators to see which topics are hidden and which are not when looking at a forum.  Otherwise,
one has to click into each topic to see whether it is hidden.

Added a span with classes "hidden" and "icon" to the topic partial, which is added to the topic view when the topic is hidden. Using this span, one can create an icon in a topics view to identify hidden topics. 
