### PR TITLE
Added a list of topics to the moderation view

### DIFF
--- a/app/views/forem/moderation/index.html.erb
+++ b/app/views/forem/moderation/index.html.erb
@@ -11,3 +11,17 @@
   </div>
   <%= submit_tag "Moderate", :class => "btn btn-primary" %>
 <% end %>
+
+<h3><%= t('topics_count', :count => @topics.count, :scope => 'forem.forum') %></h3>
+
+<div id='topics'>
+  <% @topics.limit(25).each_with_index do |topic, topic_counter| %>
+    <div id='topic_<%= topic_counter + 1 %>' class='topic <%= cycle('odd', 'even') -%>'>
+      <div class='moderation alert'>
+        <%= link_to forem_emojify(topic.subject),
+                    forem.forum_topic_path(forum, topic) %>
+      </div>
+    </div>
+  <% end %>
+</div>
+

--- a/spec/features/moderation/topic_moderation_spec.rb
+++ b/spec/features/moderation/topic_moderation_spec.rb
@@ -17,6 +17,33 @@ describe "moderation" do
       forum.moderators << group
       sign_in(moderator)
     end
+    
+    context "moderation tools view" do
+      before do
+        visit forum_path(forum)
+        click_link "Moderation Tools"
+      end
+      
+      it "should have no posts" do
+        page.should have_content("No posts")        
+      end
+      
+      it "should have 1 topic" do
+        page.should have_content("1 topic")
+        within("#topics") do
+          assert find("#topic_1")
+          assert find(".topic")
+          assert find(".odd")
+        end
+      end
+
+      it "should have a link to the topic moderation page" do
+        assert find_link("FIRST TOPIC")
+        click_link("FIRST TOPIC")
+        assert page.current_path.should match(forum_topic_path(forum, topic))
+      end
+
+    end
 
     context "singular moderation" do
       it "can approve a topic by a new user" do


### PR DESCRIPTION
The moderation index only showed posts that needed moderation, but not topics.  Added a list of topics that need moderation.

I went with a list of links rather than complete topics, as complete topics are visually pretty large and would make the view less clear.  A list of complete topics is also more complex to implement.

There is another earlier commit (included here) that used forms in the view, but I overwrote it, because I decided links are clearer.
