### PR TITLE
fix friendly_id

### DIFF
--- a/app/models/forem/category.rb
+++ b/app/models/forem/category.rb
@@ -3,7 +3,7 @@ require 'friendly_id'
 module Forem
   class Category < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => :slugged
+    friendly_id :name, :use => [:slugged, :finders]
 
     has_many :forums
     validates :name, :presence => true

--- a/app/models/forem/forum.rb
+++ b/app/models/forem/forum.rb
@@ -5,7 +5,7 @@ module Forem
     include Forem::Concerns::Viewable
 
     extend FriendlyId
-    friendly_id :name, :use => :slugged
+    friendly_id :name, :use => [:slugged, :finders]
 
     belongs_to :category
 

--- a/app/models/forem/topic.rb
+++ b/app/models/forem/topic.rb
@@ -20,7 +20,7 @@ module Forem
     attr_accessor :moderation_option
 
     extend FriendlyId
-    friendly_id :subject, :use => :slugged
+    friendly_id :subject, :use => [:slugged, :finders]
 
     belongs_to :forum
     belongs_to :user, :class_name => Forem.user_class.to_s


### PR DESCRIPTION
Hello,

I am using your gem with rails4.

Here is a small fix for the branch rails4 in order to work with friendly_id 5.0 https://github.com/norman/friendly_id

It avoids errors like "Couldn't find Forem::Category with id=general" for the url : http://localhost:3000/forums/categories/general

Best regards
