### PR TITLE
Added attr_accessible to Forem Category on rails4 branch

### DIFF
--- a/app/models/forem/category.rb
+++ b/app/models/forem/category.rb
@@ -7,6 +7,7 @@ module Forem
 
     has_many :forums
     validates :name, :presence => true
+    attr_accessible :name
 
     def to_s
       name

--- a/app/models/forem/forum.rb
+++ b/app/models/forem/forum.rb
@@ -16,6 +16,8 @@ module Forem
 
     validates :category, :name, :description, :presence => true
 
+    attr_accessible :category_id, :title, :name, :description, :moderator_ids
+
     alias_attribute :title, :name
 
     # Fix for #339

--- a/app/models/forem/group.rb
+++ b/app/models/forem/group.rb
@@ -5,6 +5,8 @@ module Forem
     has_many :memberships
     has_many :members, :through => :memberships, :class_name => Forem.user_class.to_s
 
+    attr_accessible :name
+
     def to_s
       name
     end

--- a/app/models/forem/membership.rb
+++ b/app/models/forem/membership.rb
@@ -2,5 +2,7 @@ module Forem
   class Membership < ActiveRecord::Base
     belongs_to :group
     belongs_to :member, :class_name => Forem.user_class.to_s
+
+    attr_accessible :member_id, :group_id
   end
 end

--- a/app/models/forem/moderator_group.rb
+++ b/app/models/forem/moderator_group.rb
@@ -2,5 +2,7 @@ module Forem
   class ModeratorGroup < ActiveRecord::Base
     belongs_to :forum, :inverse_of => :moderator_groups
     belongs_to :group
+
+    attr_accessible :group_id
   end
 end

--- a/app/models/forem/post.rb
+++ b/app/models/forem/post.rb
@@ -17,6 +17,8 @@ module Forem
     # Used in the moderation tools partial
     attr_accessor :moderation_option
 
+    attr_accessible :text, :reply_to_id
+
     belongs_to :topic
     belongs_to :user,     :class_name => Forem.user_class.to_s
     belongs_to :reply_to, :class_name => "Post"

--- a/app/models/forem/subscription.rb
+++ b/app/models/forem/subscription.rb
@@ -5,6 +5,8 @@ module Forem
 
     validates :subscriber_id, :presence => true
 
+    attr_accessible :subscriber_id
+
     def send_notification(post_id)
       # If a user cannot be found, then no-op
       # This will happen if the user record has been deleted.

--- a/app/models/forem/topic.rb
+++ b/app/models/forem/topic.rb
@@ -22,6 +22,9 @@ module Forem
     extend FriendlyId
     friendly_id :subject, :use => [:slugged, :finders]
 
+    attr_accessible :subject, :posts_attributes
+    attr_accessible :subject, :posts_attributes, :pinned, :locked, :hidden, :forum_id, :as => :admin
+
     belongs_to :forum
     belongs_to :user, :class_name => Forem.user_class.to_s
     has_many   :subscriptions

--- a/app/models/forem/view.rb
+++ b/app/models/forem/view.rb
@@ -7,6 +7,8 @@ module Forem
 
     validates :viewable_id, :viewable_type, :presence => true
 
+    attr_accessible :user, :current_viewed_at, :count
+
     def viewed_at
       updated_at
     end


### PR DESCRIPTION
This broke the installer for me [#325](https://github.com/radar/forem/issues/325) as `Forem::Category.create(:name => 'General')` in `db/seeds.rb` would not run due to rails 4 strong parameters. Fix already exists on master.
