### PR TITLE
Bump select2-rails dependency

### DIFF
--- a/forem.gemspec
+++ b/forem.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'workflow', '0.8.0'
   s.add_dependency 'gemoji', '= 1.1.2'
   s.add_dependency 'decorators', '~> 1.0.2'
-  s.add_dependency 'select2-rails', '3.4.3'
+  s.add_dependency 'select2-rails', '~> 3.4.3'
 end


### PR DESCRIPTION
I wasn't able to bundle the 'forem' gem on 'spree' 2-1-stable because of the fixed '3.4.3' version. After the bump, everything worked fine.
