### PR TITLE
Mention the fact that Devise does not provide 'name' column by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ def to_s
 end
 ```
 
+Please note that if you are using Devise, User model does not have `name` column by default,
+so you either should use custom migration to add it or use another column (`email` for example).
+
 It also depends on an `email` method for displaying avatars using [Gravatar](http://gravatar.com). If you don't have an `email` attribute on the model, define a new method:
 
 ```ruby


### PR DESCRIPTION
Partially fixes https://github.com/radar/forem/issues/495.

Some users (like me :)) may forget about the fact that Devise does not provide `name` column by default and such error raises: `undefined local variable or method`name' for #User:0x00000003c72f60`.
