### PR TITLE
Use Kaminari configuration if present

### DIFF
--- a/app/controllers/forem/application_controller.rb
+++ b/app/controllers/forem/application_controller.rb
@@ -9,6 +9,18 @@ class Forem::ApplicationController < ApplicationController
     Forem::Ability.new(forem_user)
   end
 
+  # Kaminari defaults page_method_name to :page, will_paginate always uses
+  # :page
+  def pagination_method
+    defined?(Kaminari) ? Kaminari.config.page_method_name : :page
+  end
+
+  # Kaminari defaults param_name to :page, will_paginate always uses :page
+  def pagination_param
+    defined?(Kaminari) ? Kaminari.config.param_name : :page
+  end
+  helper_method :pagination_param
+
   private
 
   def authenticate_forem_user

--- a/app/controllers/forem/forums_controller.rb
+++ b/app/controllers/forem/forums_controller.rb
@@ -16,7 +16,10 @@ module Forem
         @forum.topics.visible.approved_or_pending_review_for(forem_user)
       end
 
-      @topics = @topics.by_pinned_or_most_recent_post.page(params[:page]).per(Forem.per_page)
+      @topics = @topics.by_pinned_or_most_recent_post
+
+      # Kaminari allows to configure the method and param used
+      @topics = @topics.send(pagination_method, params[pagination_param]).per(Forem.per_page)
 
       respond_to do |format|
         format.html

--- a/app/controllers/forem/posts_controller.rb
+++ b/app/controllers/forem/posts_controller.rb
@@ -53,14 +53,14 @@ module Forem
     def authorize_edit_post_for_forum!
       authorize! :edit_post, @topic.forum
     end
-    
+
     def authorize_destroy_post_for_forum!
       authorize! :destroy_post, @topic.forum
     end
 
     def create_successful
       flash[:notice] = t("forem.post.created")
-      redirect_to forum_topic_url(@topic.forum, @topic, :page => @topic.last_page)
+      redirect_to forum_topic_url(@topic.forum, @topic, pagination_param => @topic.last_page)
     end
 
     def create_failed

--- a/app/controllers/forem/topics_controller.rb
+++ b/app/controllers/forem/topics_controller.rb
@@ -8,7 +8,10 @@ module Forem
     def show
       if find_topic
         register_view(@topic, forem_user)
-        @posts = find_posts(@topic).page(params[:page]).per(Forem.per_page)
+        @posts = find_posts(@topic)
+
+        # Kaminari allows to configure the method and param used
+        @posts = @posts.send(pagination_method, params[pagination_param]).per(Forem.per_page)
       end
     end
 

--- a/app/helpers/forem/topics_helper.rb
+++ b/app/helpers/forem/topics_helper.rb
@@ -3,7 +3,7 @@ module Forem
     def link_to_latest_post(topic)
       post = relevant_posts(topic).last
       text = "#{time_ago_in_words(post.created_at)} #{t("ago_by")} #{post.user}"
-      link_to text, forem.forum_topic_path(post.topic.forum, post.topic, :anchor => "post-#{post.id}", :page => topic.last_page)
+      link_to text, forem.forum_topic_path(post.topic.forum, post.topic, :anchor => "post-#{post.id}", pagination_param => topic.last_page)
     end
 
     def new_since_last_view_text(topic)


### PR DESCRIPTION
First of all, this is not a kaminari vs will_paginate patch but it's [related to](https://github.com/amatsuda/kaminari/issues/162#ref-commit-3cf929f). In that commit amatsuda introduces some configuration variables for kaminari. I'm using them like

```
Kaminari.configure do |config|
  config.page_method_name = :pagina
  config.param_name = :pagina
end
```

not because of conflict, but for i18n issues. And forem is still calling `page` and using `params[:page]`.
This patch uses that configuration if present, and defaults to `page` if not.

I can add some tests if this approach is welcome.
