### PR TITLE
Windows platform should be specified in Gemfile to install required gems...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,8 @@ platforms :jruby do
 end
 
 group :test do
-  platforms :ruby do
-    gem "forem-redcarpet", :github => "radar/forem-redcarpet", :branch => "master"
+  platforms :ruby, :mingw do
+    gem "forem-redcarpet"
     gem "mysql2"
     gem "pg"
     gem "sqlite3"


### PR DESCRIPTION
... in testing env (fixes this issue https://github.com/radar/forem/issues/500). We also shouldn't use `"forem-redcarpet"` directly from master branch as new version was released two days ago.
