### PR TITLE
Cannot quote deleted post

### DIFF
--- a/app/controllers/forem/posts_controller.rb
+++ b/app/controllers/forem/posts_controller.rb
@@ -17,7 +17,7 @@ module Forem
       if params[:quote] && @reply_to_post
         @post.text = view_context.forem_quote(@reply_to_post.text)
       elsif params[:quote] && !@reply_to_post
-        flash[:notice] = t("forem.post.cannot_quote")
+        flash[:notice] = t("forem.post.cannot_quote_deleted_post")
         redirect_to [@topic.forum, @topic]
       end
     end

--- a/app/controllers/forem/posts_controller.rb
+++ b/app/controllers/forem/posts_controller.rb
@@ -17,7 +17,7 @@ module Forem
       if params[:quote] && @reply_to_post
         @post.text = view_context.forem_quote(@reply_to_post.text)
       elsif params[:quote] && !@reply_to_post
-        flash[:notice] = "The post you tried to quote does not exist anymore."
+        flash[:notice] = t("forem.post.cannot_quote")
         redirect_to [@topic.forum, @topic]
       end
     end

--- a/app/controllers/forem/posts_controller.rb
+++ b/app/controllers/forem/posts_controller.rb
@@ -14,7 +14,12 @@ module Forem
       @post = @topic.posts.build
       find_reply_to_post
 
-      @post.text = view_context.forem_quote(@reply_to_post.text) if params[:quote]
+      if params[:quote] && @reply_to_post
+        @post.text = view_context.forem_quote(@reply_to_post.text)
+      elsif params[:quote] && !@reply_to_post
+        flash[:notice] = "The post you tried to quote does not exist anymore."
+        redirect_to [@topic.forum, @topic]
+      end
     end
 
     def create

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,6 +168,7 @@ en:
       deleted_with_topic: Only post in topic deleted. Topic also deleted.
       cannot_delete: You cannot delete a post you do not own.
       in_reply_to: In reply to
+      cannot_quote: The post you tried to quote does not exist anymore.
     posts:
       moderation:
         moderate: Moderate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,7 +168,7 @@ en:
       deleted_with_topic: Only post in topic deleted. Topic also deleted.
       cannot_delete: You cannot delete a post you do not own.
       in_reply_to: In reply to
-      cannot_quote: The post you tried to quote does not exist anymore.
+      cannot_quote_deleted_post: The post you tried to quote does not exist anymore.
     posts:
       moderation:
         moderate: Moderate

--- a/spec/features/posts_spec.rb
+++ b/spec/features/posts_spec.rb
@@ -87,7 +87,7 @@ describe "posts" do
           click_link("Quote")
         end
 
-        flash_notice!(I18n.t("forem.post.cannot_quote"))
+        flash_notice!(I18n.t("forem.post.cannot_quote_deleted_post"))
       end
     end
 

--- a/spec/features/posts_spec.rb
+++ b/spec/features/posts_spec.rb
@@ -74,6 +74,23 @@ describe "posts" do
       end
     end
 
+    context "quoting" do
+      it "cannot quote deleted post" do
+        other_user = FactoryGirl.create(:user, :login => 'other_forem_user', :email => "maryanne@boblaw.com")
+        topic.posts << FactoryGirl.build(:approved_post, :user => other_user)
+        @second_post = topic.posts[1]
+
+        visit forum_topic_path(forum, topic)
+        @second_post.delete
+
+        within(selector_for(:second_post)) do
+          click_link("Quote")
+        end
+
+        flash_notice!("The post you tried to quote does not exist anymore.")
+      end
+    end
+
     context "editing posts in topics" do
       before do
         other_user = FactoryGirl.create(:user, :login => 'other_forem_user', :email => "maryanne@boblaw.com")

--- a/spec/features/posts_spec.rb
+++ b/spec/features/posts_spec.rb
@@ -87,7 +87,7 @@ describe "posts" do
           click_link("Quote")
         end
 
-        flash_notice!("The post you tried to quote does not exist anymore.")
+        flash_notice!(I18n.t("forem.post.cannot_quote"))
       end
     end
 


### PR DESCRIPTION
Clicking "Quote" on a post that has since been deleted throws the following error in an application using forem:

```
Error Message:
NoMethodError: undefined method `text' for nil:NilClass

Where:
forem/posts#new
[GEM_ROOT]/bundler/gems/forem-ef6a4679928c/app/controllers/forem/posts_controller.rb, line 17
```

I wasn't sure how to add a new flash notice... it's just English. (I'm not sure if adding a translation for it to the `en.yml` file but not the others would cause problems.)

This pull request is intended for the master branch as well.
