### PR TITLE
Use POST for subscribing/unsubscribing from forum topics.

### DIFF
--- a/app/views/forem/topics/show.html.erb
+++ b/app/views/forem/topics/show.html.erb
@@ -11,9 +11,9 @@
       <% end %>
       <% if forem_user %>
         <% if !@topic.subscriber?(forem_user.id) %>
-          <%= link_to t(".subscribe"), forem.subscribe_forum_topic_path(@forum, @topic), :class => "btn btn-success" %>
+          <%= link_to t(".subscribe"), forem.subscribe_forum_topic_path(@forum, @topic), :method => :post, :class => "btn btn-success" %>
         <% else %>
-          <%= link_to t(".unsubscribe"), forem.unsubscribe_forum_topic_path(@forum, @topic), :class => "btn btn-danger" %>
+          <%= link_to t(".unsubscribe"), forem.unsubscribe_forum_topic_path(@forum, @topic), :method => :post, :class => "btn btn-danger" %>
         <% end %>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,8 @@ Forem::Engine.routes.draw do
   resources :forums, :only => [:index, :show] do
     resources :topics do
       member do
-        get :subscribe
-        get :unsubscribe
+        post :subscribe
+        post :unsubscribe
       end
     end
   end

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -22,6 +22,23 @@ describe Forem::TopicsController do
     end
   end
 
+  context "without permission to read a topic" do
+    let(:forum) { FactoryGirl.create(:forum) }
+    let(:topic) { FactoryGirl.create(:approved_topic, :forum => forum) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    before do
+      sign_in(user)
+      User.any_instance.stub(:can_read_forem_topic?).and_return(false)
+    end
+
+    it "cannot subscribe to a topic" do
+      post :subscribe, :forum_id => forum.id, :id => topic.id
+
+      response.should redirect_to(root_path)
+      flash[:alert].should == I18n.t('forem.access_denied')
+    end
+  end
 
   context "not signed in" do
     let(:forum) { create(:forum) }

--- a/spec/features/permissions/topics_spec.rb
+++ b/spec/features/permissions/topics_spec.rb
@@ -38,16 +38,4 @@ describe 'topic permissions' do
       access_denied!
     end
   end
-
-  context "without permission to read a topic" do
-    before do
-      sign_in(user)
-      User.any_instance.stub(:can_read_forem_topic?).and_return(false)
-    end
-
-    it "cannot subscribe to a topic" do
-      visit subscribe_forum_topic_path(topic.forum, topic)
-      access_denied!
-    end
-  end
 end


### PR DESCRIPTION
Use POST request with `authenticity_token` instead of GET to protect topics (un)subscribing process from CSRF attack.
