### PR TITLE
Update Forem::Forum order in the default_scope

### DIFF
--- a/app/models/forem/forum.rb
+++ b/app/models/forem/forum.rb
@@ -19,7 +19,7 @@ module Forem
     alias_attribute :title, :name
 
     # Fix for #339
-    default_scope { order('name ASC') }
+    default_scope { order(:name) }
 
     def last_post_for(forem_user)
       if forem_user && (forem_user.forem_admin? || moderator?(forem_user))


### PR DESCRIPTION
Fix to avoid ambiguous column errors
