### PR TITLE
Fixed a regression introduced about by_pinned_or_most_recent_post

### DIFF
--- a/app/models/forem/topic.rb
+++ b/app/models/forem/topic.rb
@@ -52,8 +52,9 @@ module Forem
       end
 
       def by_pinned_or_most_recent_post
-        order('forem_topics.last_post_at DESC').order('forem_topics.pinned DESC')
-        #order('forem_topics.id')
+	order('forem_topics.pinned DESC').
+        order('forem_topics.last_post_at DESC').
+        order('forem_topics.id')
       end
 
       def pending_review

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -47,6 +47,13 @@ describe Forem::Topic do
     end
   end
 
+  describe ".by_pinned_or_most_recent_post" do
+    it "should show topics by pinned then by most recent post" do
+      ordering = Forem::Topic.by_pinned_or_most_recent_post.order_values
+      ordering.should == ["forem_topics.pinned DESC", "forem_topics.last_post_at DESC", "forem_topics.id"] 
+    end
+  end
+
   describe "helper methods" do
     describe "#subscribe_user" do
       let(:subscription_user) { FactoryGirl.create(:user) }


### PR DESCRIPTION
I noticed a change on by_pinned_or_most_recent_post I could not explain and that caused a strange behavior on my pinned topics.
I just reverted to what the code was on master, and everything works again.
