### PR TITLE
Moderation and unapproved users

### DIFF
--- a/app/views/forem/moderation/index.html.erb
+++ b/app/views/forem/moderation/index.html.erb
@@ -9,7 +9,6 @@
       <%= render posts, :mass_moderation => true %>
     <% end %>
   </div>
-  <%= submit_tag t('forem.posts.moderation.moderate'), :class => "btn btn-primary" %>
 <% end %>
 
 <h3><%= t('topics_count', :count => @topics.count, :scope => 'forem.forum') %></h3>


### PR DESCRIPTION
I have tried to look into this issue https://github.com/radar/forem/issues/474 But I do not quite understand the logic behind the rendering of posts and topics inside moderartion. Should the admin see all the unapproved posts and topics? I have tried to change this line https://github.com/MATI-INT/forem/blob/rails4/app/controllers/forem/moderation_controller.rb#L8 to just `@posts = forum.posts.pending_review` and all posts are being shown from the unapproved topic but it breaks the test at `/spec/features/moderation/topic_moderation_spec.rb` ("should have no posts" and "should have 1 post"):

```

  1) moderation  of topics moderation tools view should have no posts
     Failure/Error: page.should have_content("No posts")
       expected there to be text "No posts" in "Signed in as moderator Sign out
Moderation tools for Welcome to Forem! 1 post Welcome to Forem! » FIRST TOPIC Th
is post is currently pending review. Only the user who posted it and moderators
can view it. Approve Spam forem_user forem_user less than a minute ago This is a
 brand new post Reply Quote 1 topic FIRST TOPIC"
     # ./spec/features/moderation/topic_moderation_spec.rb:28:in `block (4 level
s) in <top (required)>'

  2) moderation  of topics moderation tools view should have 1 topic
     Failure/Error: assert find(".odd")
     Capybara::ElementNotFound:
       Unable to find css ".odd"
     # ./spec/features/moderation/topic_moderation_spec.rb:36:in `block (5 level
s) in <top (required)>'
     # ./spec/features/moderation/topic_moderation_spec.rb:33:in `block (4 level
s) in <top (required)>'
```

Still I have found another issue: there is an unnecessary `submit_tag` inside 'moderation/index`, because each post pending for review already has this button.
