### PR TITLE
Remove duplicate friendly_id dependency

### DIFF
--- a/forem.gemspec
+++ b/forem.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 4.0.3'
   s.add_dependency 'simple_form', '~> 3.0.1'
   s.add_dependency 'sanitize', '2.0.6'
-  s.add_dependency 'friendly_id', '5.0.2'
   s.add_dependency 'workflow', '1.0.0'
   s.add_dependency 'gemoji', '= 1.1.2'
   s.add_dependency 'decorators', '~> 1.0.2'


### PR DESCRIPTION
This duplicate dependency has been in the gemspec for months, is it a mistake or is there a reason? It causes an "invalid gemspec" error when installing.
