### PR TITLE
Fix Markdown formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,10 +26,10 @@ Here's a quick guide:
 2. Run the tests. We only take pull requests with passing tests, and it's great
 to know that you have a clean slate:
 
-```shell
-bundle exec rake forem:dummy_app
-bundle exec rspec spec
-```
+   ```shell
+   bundle exec rake forem:dummy_app
+   bundle exec rspec spec
+   ```
 
 3. Add a test for your change. Only refactoring and documentation changes
 require no new tests. If you are adding functionality or fixing a bug, we need


### PR DESCRIPTION
Minor change. This indentation fixes the numbering in the contribution guidelines.
