### PR TITLE
Sort forums and categories by order

### DIFF
--- a/app/controllers/forem/admin/categories_controller.rb
+++ b/app/controllers/forem/admin/categories_controller.rb
@@ -35,7 +35,7 @@ module Forem
       private
 
       def category_params
-        params.require(:category).permit(:name)
+        params.require(:category).permit(:name, :order)
       end
 
       def find_category

--- a/app/controllers/forem/forums_controller.rb
+++ b/app/controllers/forem/forums_controller.rb
@@ -4,7 +4,7 @@ module Forem
     helper 'forem/topics'
 
     def index
-      @categories = Forem::Category.all
+      @categories = Forem::Category.order(:order)
     end
 
     def show

--- a/app/controllers/forem/forums_controller.rb
+++ b/app/controllers/forem/forums_controller.rb
@@ -4,7 +4,7 @@ module Forem
     helper 'forem/topics'
 
     def index
-      @categories = Forem::Category.order(:order)
+      @categories = Forem::Category.order('order DESC')
     end
 
     def show

--- a/app/models/forem/category.rb
+++ b/app/models/forem/category.rb
@@ -7,6 +7,7 @@ module Forem
 
     has_many :forums
     validates :name, :presence => true
+    validates :order, numericality: { only_integer: true }
 
     def to_s
       name

--- a/app/models/forem/forum.rb
+++ b/app/models/forem/forum.rb
@@ -15,11 +15,12 @@ module Forem
     has_many :moderator_groups
 
     validates :category, :name, :description, :presence => true
+    validates :order, numericality: { only_integer: true }
 
     alias_attribute :title, :name
 
     # Fix for #339
-    default_scope { order(:name) }
+    default_scope { order(:order) }
 
     def last_post_for(forem_user)
       if forem_user && (forem_user.forem_admin? || moderator?(forem_user))

--- a/app/views/forem/admin/categories/_form.html.erb
+++ b/app/views/forem/admin/categories/_form.html.erb
@@ -1,4 +1,5 @@
 <%= simple_form_for [forem, :admin, @category] do |f| %>
   <%= f.input :name %>
+  <%= f.input :order %>
   <%= f.submit :class => "btn btn-primary" %>
 <% end %>

--- a/app/views/forem/admin/forums/_form.html.erb
+++ b/app/views/forem/admin/forums/_form.html.erb
@@ -1,6 +1,7 @@
 <%= simple_form_for [forem, :admin, @forum] do |f| %>
   <%= f.association :category, :include_blank => false %>
   <%= f.input :title %>
+  <%= f.input :order %>
   <%= f.input :description, :as => :text %>
 
   <h3><%= t('forem.admin.forum.moderator_groups') %></h3>

--- a/db/migrate/20140917034000_add_order_to_categories.rb
+++ b/db/migrate/20140917034000_add_order_to_categories.rb
@@ -1,0 +1,5 @@
+class AddOrderToCategories < ActiveRecord::Migration
+  def change
+    add_column :forem_categories, :order, :integer, :default => 0
+  end
+end

--- a/db/migrate/20140917201619_add_order_to_forums.rb
+++ b/db/migrate/20140917201619_add_order_to_forums.rb
@@ -1,0 +1,5 @@
+class AddOrderToForums < ActiveRecord::Migration
+  def change
+    add_column :forem_forums, :order, :integer, :default => 0
+  end
+end


### PR DESCRIPTION
Unfortunately, there really isn't a way to make sure that your forums and categories are sorted in the order that you want. To make this possible, I've added a order field to categories and forums, which is the order that they will be sorted in.

I needed this, so if it's useless here, then feel free to close it, or let me know of any issues :smile: 
