### PR TITLE
Missing branch specification in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Installing Forem is easy.
 If you're using Rails 3:
 
 ```ruby
-gem 'forem', :github => "radar/forem"
+gem 'forem', :github => "radar/forem", :branch => "rails3"
 ```
 
 For Rails 4, use the `rails4` branch:


### PR DESCRIPTION
Forem doesn't have a master branch, so the branch name should be specified.
