### PR TITLE
Fix a few sorting issues

### DIFF
--- a/app/controllers/forem/admin/categories_controller.rb
+++ b/app/controllers/forem/admin/categories_controller.rb
@@ -4,7 +4,7 @@ module Forem
       before_filter :find_category, :only => [:edit, :update, :destroy]
 
       def index
-        @categories = Forem::Category.all
+        @categories = Forem::Category.by_position
       end
 
       def new

--- a/app/controllers/forem/admin/forums_controller.rb
+++ b/app/controllers/forem/admin/forums_controller.rb
@@ -36,7 +36,7 @@ module Forem
       private
 
       def forum_params
-        params.require(:forum).permit(:category_id, :title, :description, { :moderator_ids => []})
+        params.require(:forum).permit(:category_id, :title, :description, :position, { :moderator_ids => []})
       end
 
       def find_forum

--- a/app/controllers/forem/forums_controller.rb
+++ b/app/controllers/forem/forums_controller.rb
@@ -4,7 +4,7 @@ module Forem
     helper 'forem/topics'
 
     def index
-      @categories = Forem::Category.all
+      @categories = Forem::Category.by_position
     end
 
     def show

--- a/app/controllers/forem/forums_controller.rb
+++ b/app/controllers/forem/forums_controller.rb
@@ -4,7 +4,7 @@ module Forem
     helper 'forem/topics'
 
     def index
-      @categories = Forem::Category.order('position DESC')
+      @categories = Forem::Category.all
     end
 
     def show

--- a/app/models/forem/category.rb
+++ b/app/models/forem/category.rb
@@ -9,6 +9,8 @@ module Forem
     validates :name, :presence => true
     validates :position, numericality: { only_integer: true }
 
+    default_scope { order(:position) }
+
     def to_s
       name
     end

--- a/app/models/forem/category.rb
+++ b/app/models/forem/category.rb
@@ -9,7 +9,7 @@ module Forem
     validates :name, :presence => true
     validates :position, numericality: { only_integer: true }
 
-    default_scope { order(:position) }
+    scope :by_position, -> { order(:position) }
 
     def to_s
       name

--- a/spec/controllers/admin/forums_controller_spec.rb
+++ b/spec/controllers/admin/forums_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Forem::Admin::ForumsController do
+  let(:user) { FactoryGirl.create(:user, forem_admin: true) }
+
+  before do
+    controller.stub current_user: user
+  end
+
+  it "forum_params permits all the necessary fields" do
+    group = FactoryGirl.create(:group)
+    category = FactoryGirl.create(:category)
+
+    Forem::Forum.should_receive(:new).with({
+      category_id: category.id.to_s,
+      title: 'Forum title',
+      description: 'Description for the forum',
+      position: '1',
+      moderator_ids: [group.id.to_s]
+    }.with_indifferent_access).and_call_original
+
+    post :create, forum: {
+      category_id: category.id,
+      title: 'Forum title',
+      description: 'Description for the forum',
+      position: 1,
+      moderator_ids: [group.id]
+    }
+  end
+
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -14,9 +14,9 @@ describe Forem::Category do
     end
   end
 
-  it "is scoped by default" do
+  it "by_position scope orders by position asc" do
     # gsub replaces non-standard quotes (MySQL) with standard ones
-    Forem::Category.all.to_sql.gsub(/`/, '"').should =~ /ORDER BY \"forem_categories\".\"position\" ASC/
+    Forem::Category.by_position.to_sql.gsub(/`/, '"').should =~ /ORDER BY \"forem_categories\".\"position\" ASC/
   end
 
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -14,4 +14,9 @@ describe Forem::Category do
     end
   end
 
+  it "is scoped by default" do
+    # gsub replaces non-standard quotes (MySQL) with standard ones
+    Forem::Category.all.to_sql.gsub(/`/, '"').should =~ /ORDER BY \"forem_categories\".\"position\" ASC/
+  end
+
 end


### PR DESCRIPTION
Currently forum catgories are sorted "position DESC" in ForumsController#index, which is the opposite from the default forum sorting. Also, forum position can't be set on the forum form in the admin interface, since :position is not permitted.

This commit does this:
- default Category sorting to "position ASC", same as with the Forum model
- allow forums "position" to be mass-assigned
