### PR TITLE
Pass option to forum_pages_widget helper

### DIFF
--- a/app/helpers/forem/application_helper.rb
+++ b/app/helpers/forem/application_helper.rb
@@ -19,7 +19,7 @@ module Forem
     def forem_pages_widget(collection, options={})
       if collection.num_pages > 1
         content_tag :div, :class => 'pages' do
-          (t('forem.common.pages') + ':' + forem_paginate(collection, options)).html_safe
+          (forem_paginate(collection, options)).html_safe
         end
       end
     end

--- a/app/helpers/forem/application_helper.rb
+++ b/app/helpers/forem/application_helper.rb
@@ -16,10 +16,10 @@ module Forem
       forem_format(text)
     end
 
-    def forem_pages_widget(collection)
+    def forem_pages_widget(collection, options={})
       if collection.num_pages > 1
         content_tag :div, :class => 'pages' do
-          (t('forem.common.pages') + ':' + forem_paginate(collection)).html_safe
+          (t('forem.common.pages') + ':' + forem_paginate(collection, options)).html_safe
         end
       end
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Forem::ApplicationHelper do
+  describe 'forem_pages_widget' do
+    context 'with options' do
+      context 'when using will_paginate' do
+        it 'calls will_paginate with the options' do
+          # Simulate an app using will_paginate
+          allow(Forem::ApplicationHelper).to receive(:respond_to?).with(:will_paginate).and_return(true)
+          allow(helper).to receive(:will_paginate).and_return('content')
+          collection = double(Forem::Post, num_pages: 10, current_page: 1, total_pages: 3, limit_value: 1)
+
+          helper.should_receive(:will_paginate).with(collection, test_option: :test)
+
+          helper.forem_pages_widget(collection, test_option: :test)
+        end
+      end
+
+      context 'when using kaminari' do
+        it 'calls paginate with the options' do
+          allow(helper).to receive(:paginate).and_return('content')
+          collection = double(Forem::Post, num_pages: 10, current_page: 1, total_pages: 3, limit_value: 1)
+
+          helper.should_receive(:paginate).with(collection, test_option: :test)
+
+          helper.forem_pages_widget(collection, test_option: :test)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The view files in forem uses `forem_pages_widget` helper to render pagination, but there is no way to pass in additional arguments. I thought adding arguments might be useful.

For instance, such need arises when using will_paginate-bootstrap to style pagination rendered by will_paginate. People need to pass `renderer: BootstrapPagination::Rails` to will_paginate helper, but currently there is no easy way to do so.
