### PR TITLE
For tests, use a newer version of Devise that supports Ruby on Rails 4.2.

### DIFF
--- a/forem.gemspec
+++ b/forem.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'factory_girl_rails', '~> 4.4.1'
   s.add_development_dependency 'database_cleaner', '~> 1.0.0'
-  s.add_development_dependency 'devise', '3.3.0'
+  s.add_development_dependency 'devise', '~> 3.4.0'
   s.add_development_dependency 'kaminari', '~> 0.15.0'
   s.add_development_dependency 'timecop', '~> 0.6.1'
   s.add_development_dependency 'sass-rails', '~> 4.0'


### PR DESCRIPTION
Without this change, `bundle exec rspec spec` on Ruby on Rails 4.2 results in an error with no tests being run.

With this change, the tests run, albeit with a few failing tests and a load of deprecation messages.
