### PR TITLE
validate length of topics subject

### DIFF
--- a/app/models/forem/topic.rb
+++ b/app/models/forem/topic.rb
@@ -29,7 +29,7 @@ module Forem
     has_many   :posts, -> { order "forem_posts.created_at ASC"}, :dependent => :destroy
     accepts_nested_attributes_for :posts
 
-    validates :subject, :presence => true
+    validates :subject, :presence => true, :length => { maximum: 255 }
     validates :user, :presence => true
 
     before_save  :set_first_post_user

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -21,6 +21,11 @@ describe Forem::Topic do
       topic.subject = nil
       topic.should_not be_valid
     end
+
+    it "requires a subject not too long" do
+      topic.subject = 'x' * 256
+      topic.should_not be_valid
+    end
   end
 
   describe "pinning" do


### PR DESCRIPTION
Avoid 500 error when topics subject is to long for string type
