### PR TITLE
Add dependent => destroy to forum/topic views and topic subscriptions

### DIFF
--- a/app/models/forem/concerns/viewable.rb
+++ b/app/models/forem/concerns/viewable.rb
@@ -6,7 +6,7 @@ module Forem
       extend ActiveSupport::Concern
 
       included do
-        has_many :views, :as => :viewable
+        has_many :views, :as => :viewable, :dependent => :destroy
       end
 
       def view_for(user)

--- a/app/models/forem/topic.rb
+++ b/app/models/forem/topic.rb
@@ -25,7 +25,7 @@ module Forem
 
     belongs_to :forum
     belongs_to :forem_user, :class_name => Forem.user_class.to_s, :foreign_key => :user_id
-    has_many   :subscriptions
+    has_many   :subscriptions, :dependent => :destroy
     has_many   :posts, -> { order "forem_posts.created_at ASC"}, :dependent => :destroy
     accepts_nested_attributes_for :posts
 

--- a/lib/forem/testing_support/factories/subscriptions.rb
+++ b/lib/forem/testing_support/factories/subscriptions.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :subscription, :class => Forem::Subscription do
+    association :subscriber, :factory => :user
+    association :topic
+  end
+end

--- a/lib/forem/testing_support/factories/views.rb
+++ b/lib/forem/testing_support/factories/views.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :forum_view, :class => Forem::View do
+    association :user
+    association :viewable, :factory => :forum
+  end
+  
+  factory :topic_view, :class => Forem::View do
+    association :user
+    association :viewable, :factory => :topic
+  end
+end

--- a/spec/models/forum_spec.rb
+++ b/spec/models/forum_spec.rb
@@ -32,6 +32,14 @@ describe Forem::Forum do
     end
   end
 
+  context "deletion" do
+    it "deletes views" do
+      FactoryGirl.create(:forum_view, :viewable => forum)
+      forum.destroy
+      Forem::View.exists?(:viewable_id => forum.id).should be_false
+    end
+  end
+
   describe "helper methods" do
     context "name" do
       it "is aliased to title" do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe Forem::Subscription do
+
+  it "is valid with valid attributes" do
+    FactoryGirl.build(:subscription).should be_valid
+  end
+
   describe "topic subscriptions" do
     before(:each) do
       Forem::Topic.any_instance.stub(:set_first_post_user)

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -16,6 +16,27 @@ describe Forem::Topic do
     end
   end
 
+  context "deletion" do
+    it "deletes posts" do
+      FactoryGirl.create(:post, :topic => topic)
+      topic.reload
+      topic.destroy
+      Forem::Post.exists?(:topic_id => topic.id).should be_false
+    end
+
+    it "deletes views" do
+      FactoryGirl.create(:topic_view, :viewable => topic)
+      topic.destroy
+      Forem::View.exists?(:viewable_id => topic.id).should be_false
+    end
+
+    it "deletes subscriptions" do
+      FactoryGirl.create(:subscription, :topic => topic)
+      topic.destroy
+      Forem::Subscription.exists?(:topic_id => topic.id).should be_false
+    end
+  end  
+
   describe "validations" do
     it "requires a subject" do
       topic.subject = nil

--- a/spec/models/view_spec.rb
+++ b/spec/models/view_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Forem::View do
+  let!(:view) { FactoryGirl.create(:topic_view) }
+
+  it "is valid with valid attributes" do
+    view.should be_valid
+  end
+
+  describe "validations" do
+    it "requires a viewable type" do
+      view.viewable_type = nil
+      view.should_not be_valid
+    end
+
+    it "requires a viewable id" do
+      view.viewable_id = nil
+      view.should_not be_valid
+    end
+  end
+
+end


### PR DESCRIPTION
To not leave behind orphaned subscription and view rows when you delete a topic or a forum or to not get a database exception when you are using foreign keys in your Forem tables, I added dependent => destroy options to topic subscriptions and viewable views.
