### PR TITLE
update of simpleform dependency in gemspec

### DIFF
--- a/forem.gemspec
+++ b/forem.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coffee-rails', '~> 4.0'
 
   s.add_dependency 'rails', '~> 4.0', '<= 4.2'
-  s.add_dependency 'simple_form', '>= 3.0.1', '<= 3.1.0'
+  s.add_dependency 'simple_form', '~> 3.0'
   s.add_dependency 'sanitize', '2.0.6'
   s.add_dependency 'workflow', '1.0.0'
   s.add_dependency 'gemoji', '= 2.1.0'

--- a/forem.gemspec
+++ b/forem.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coffee-rails', '~> 4.0'
 
   s.add_dependency 'rails', '~> 4.0', '<= 4.2'
-  s.add_dependency 'simple_form', '~> 3.0.1'
+  s.add_dependency 'simple_form', '~> 3.0.1', '<= 3.1.0'
   s.add_dependency 'sanitize', '2.0.6'
   s.add_dependency 'workflow', '1.0.0'
   s.add_dependency 'gemoji', '= 2.1.0'

--- a/forem.gemspec
+++ b/forem.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coffee-rails', '~> 4.0'
 
   s.add_dependency 'rails', '~> 4.0', '<= 4.2'
-  s.add_dependency 'simple_form', '~> 3.0.1', '<= 3.1.0'
+  s.add_dependency 'simple_form', '>= 3.0.1', '<= 3.1.0'
   s.add_dependency 'sanitize', '2.0.6'
   s.add_dependency 'workflow', '1.0.0'
   s.add_dependency 'gemoji', '= 2.1.0'


### PR DESCRIPTION
bundler stops while showing a conflict message in combination with other gem, which is dependent on simple_form 3.1 ( issue #637 )
