### PR TITLE
Fixes class reloading issue

### DIFF
--- a/app/models/forem/post.rb
+++ b/app/models/forem/post.rb
@@ -1,5 +1,3 @@
-require 'forem/state_workflow'
-
 module Forem
   class Post < ActiveRecord::Base
     include Workflow

--- a/app/models/forem/topic.rb
+++ b/app/models/forem/topic.rb
@@ -1,5 +1,4 @@
 require 'friendly_id'
-require 'forem/state_workflow'
 
 module Forem
   class Topic < ActiveRecord::Base

--- a/lib/forem.rb
+++ b/lib/forem.rb
@@ -6,7 +6,7 @@ require 'forem/autocomplete'
 require 'forem/default_permissions'
 require 'forem/platform'
 require 'forem/sanitizer'
-require 'workflow'
+require 'forem/state_workflow'
 require 'sanitize'
 
 require 'decorators'

--- a/lib/forem/state_workflow.rb
+++ b/lib/forem/state_workflow.rb
@@ -1,3 +1,5 @@
+require 'workflow'
+
 module Forem
   module StateWorkflow
     def self.included(base)


### PR DESCRIPTION
This fixes the issue for me.  Sorry, couldn't run specs because I don't want to install MySQL, but it seems like a pretty innocuous change.

Pretty sure bug was caused by something related to this:
http://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-and-require

Something about autoloading classes (in `app/`) requiring non-autoloading classes (in `lib/`).  ¯_(ツ)_/¯
