### PR TITLE
Set mysql version in Gemfile to work with latest rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ end
 group :test do
   platforms :ruby, :mingw do
     gem "forem-redcarpet"
-    gem "mysql2"
+    gem "mysql2", "~> 0.3.18"
     gem "pg"
     gem "sqlite3"
   end


### PR DESCRIPTION
This should fix the failing mysql Travis builds until the latest mysql2 + rails get along. http://stackoverflow.com/a/32466950
