### PR TITLE
Fixed german translation for edited

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -144,7 +144,7 @@ de:
       edit: Bearbeiten
       not_created: Ihre Antwort konnte nicht erstellt werden.
       not_created_topic_locked: Sie können nicht auf eines gesperrtes Thema antworten.
-      edited: Ihr Eintrag wurde bearbeiten.
+      edited: Ihr Eintrag wurde bearbeitet.
       not_edited: Ihr Eintrag konnte nicht bearbeitet werden.
       deleted: Ihr Eintrag wurde gelöscht.
       deleted_with_topic: Einziger Eintrag im Thema wurde gelöscht. Das Thema wurde entfernt.


### PR DESCRIPTION
The sentence `Ihr Eintrag wurde bearbeiten.` is wrong in german.
It needs to be `Ihr Eintrag wurde bearbeitet.`
